### PR TITLE
restructure sidbar nav so that left nav persists

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,20 +6,32 @@ import Quantities from "./components/steps/Quantities";
 import Results from "./components/steps/Results";
 import Schedules from "./components/steps/Schedules";
 import Systems from "./components/steps/Systems";
+import Sidebarlayout from "./components/layouts/SidebarLayout";
+import LeftNav from "./components/LeftNavigation";
+import { useLocation } from "react-router-dom";
 
 import "./styles/application.scss";
 
 const App = () => {
+  const location = useLocation();
+  const isFullScreen = ["/"].includes(location.pathname);
+
   return (
-    <Routes>
-      <Route path="/" element={<Landing />} />
-      <Route path="/details" element={<Details />} />
-      <Route path="/systems" element={<Systems />} />
-      <Route path="/configs" element={<Configs />} />
-      <Route path="/quantities" element={<Quantities />} />
-      <Route path="/schedules" element={<Schedules />} />
-      <Route path="/results" element={<Results />} />
-    </Routes>
+    <Sidebarlayout
+      isFullScreen={isFullScreen}
+      contentLeft={<LeftNav />}
+      contentRight={
+        <Routes>
+          <Route path="/" element={<Landing />} />
+          <Route path="/details" element={<Details />} />
+          <Route path="/systems" element={<Systems />} />
+          <Route path="/configs" element={<Configs />} />
+          <Route path="/quantities" element={<Quantities />} />
+          <Route path="/schedules" element={<Schedules />} />
+          <Route path="/results" element={<Results />} />
+        </Routes>
+      }
+    />
   );
 };
 

--- a/client/src/components/PageHeader.tsx
+++ b/client/src/components/PageHeader.tsx
@@ -1,0 +1,18 @@
+export interface PageHeaderProps {
+  headerText: string;
+}
+
+function PageHeader({ headerText }: PageHeaderProps) {
+  return (
+    <header>
+      <h1>{headerText}</h1>
+
+      <div className="save-widget">
+        <span>last saved 4 hours ago</span>
+        <button className="small inline">Save</button>
+      </div>
+    </header>
+  );
+}
+
+export default PageHeader;

--- a/client/src/components/StepNavigation.tsx
+++ b/client/src/components/StepNavigation.tsx
@@ -22,12 +22,14 @@ function StepNavigation() {
 
   return (
     <div className="step-navigation">
-      <div className="prev-container">
-        <Link to={previous.path}>
-          <i className="icon-left-open" />
-          Back
-        </Link>
-      </div>
+      {previous && (
+        <div className="prev-container">
+          <Link to={previous.path}>
+            <i className="icon-left-open" />
+            Back
+          </Link>
+        </div>
+      )}
 
       <div className="step-links">
         {steps

--- a/client/src/components/layouts/SidebarLayout.tsx
+++ b/client/src/components/layouts/SidebarLayout.tsx
@@ -5,17 +5,17 @@ import StepNavigation from "../StepNavigation";
 import "../../styles/components/sidebar-layout.scss";
 
 export interface SidebarLayoutProps {
-  heading: string;
   contentLeft: ReactNode;
   contentRight: ReactNode;
+  isFullScreen?: boolean;
 }
 
 const MIN_WIDTH = 300;
 
 const Sidebarlayout = ({
-  heading,
   contentLeft,
   contentRight,
+  isFullScreen = true,
 }: SidebarLayoutProps) => {
   const { projectDetails, leftColWidth, setLeftColWidth } = useStore(
     (state) => {
@@ -44,38 +44,31 @@ const Sidebarlayout = ({
       onMouseMove={recordDrag}
     >
       <div className="col-container">
-        <section className="left-col" style={{ width: leftColWidth }}>
-          <header>
-            All Projects &gt;
-            <strong>{projectName}</strong>
-          </header>
+        {!isFullScreen && (
+          <section className="left-col" style={{ width: leftColWidth }}>
+            <header>
+              All Projects &gt; &nbsp;
+              <strong>{projectName}</strong>
+            </header>
 
-          {contentLeft}
+            {contentLeft}
 
-          <div
-            className="dragger"
-            onMouseDown={() => setIsDragging(true)}
-          ></div>
-        </section>
+            <div
+              className="dragger"
+              onMouseDown={() => setIsDragging(true)}
+            ></div>
+          </section>
+        )}
 
         <section
           className="right-col"
           style={{ width: `calc(100vw - ${leftColWidth}px)` }}
         >
-          <header>
-            <h1>{heading}</h1>
-
-            <div className="save-widget">
-              <span>last saved 4 hours ago</span>
-              <button className="small inline">Save</button>
-            </div>
-          </header>
-
           {contentRight}
         </section>
       </div>
 
-      <StepNavigation />
+      {!isFullScreen && <StepNavigation />}
     </main>
   );
 };

--- a/client/src/components/steps/Configs.tsx
+++ b/client/src/components/steps/Configs.tsx
@@ -3,14 +3,18 @@
 import { css, jsx } from "@emotion/react/macro";
 import styled from "@emotion/styled";
 import { Fragment, useState } from "react";
-import Sidebarlayout from "../layouts/SidebarLayout";
+import PageHeader from "../PageHeader";
 import SlideOut from "../modal/ConfigSlideOut";
 
 import { colors } from "../../styleHelpers";
 
-import { useStore, Configuration, SystemTemplate, SystemType } from "../../store/store";
+import {
+  useStore,
+  Configuration,
+  SystemTemplate,
+  SystemType,
+} from "../../store/store";
 
-import LeftNav from "../LeftNavigation";
 import { TextButton } from "../Button";
 
 // step 3
@@ -34,37 +38,30 @@ const Configs = () => {
 
   // based on user configs, figure out which templates they are using
 
-
-
   return (
-    <Sidebarlayout
-      heading="Configurations"
-      contentLeft={<LeftNav />}
-      contentRight={
-        <Fragment>
-          <div>Add Configurations For The System Types You Selected</div>
-          {systemTypes.map((systemT) => {
-            const systemTypeTemplates = templates.filter(
-              (t) => t.systemType.id === systemT.id,
-            );
-            const confs = configs.filter((c) =>
-              systemTypeTemplates.map((s) => s.id).includes(c.template.id),
-            );
+    <Fragment>
+      <PageHeader headerText="Configurations" />
+      <div>Add Configurations For The System Types You Selected</div>
+      {systemTypes.map((systemT) => {
+        const systemTypeTemplates = templates.filter(
+          (t) => t.systemType.id === systemT.id,
+        );
+        const confs = configs.filter((c) =>
+          systemTypeTemplates.map((s) => s.id).includes(c.template.id),
+        );
 
-            return (
-              <SystemConfigGroup
-                key={systemT.id}
-                systemType={systemT}
-                templates={systemTypeTemplates}
-                configs={confs}
-                addConfig={addConfig}
-                removeConfig={removeConfig}
-              />
-            );
-          })}
-        </Fragment>
-      }
-    />
+        return (
+          <SystemConfigGroup
+            key={systemT.id}
+            systemType={systemT}
+            templates={systemTypeTemplates}
+            configs={confs}
+            addConfig={addConfig}
+            removeConfig={removeConfig}
+          />
+        );
+      })}
+    </Fragment>
   );
 };
 
@@ -116,9 +113,16 @@ const SystemConfigs = ({
     <SystemConfigsContainer>
       <SystemTitleContainer>
         <SystemName>{template.name}</SystemName>
-        <UploadDownload path=''></UploadDownload>
+        <UploadDownload path=""></UploadDownload>
       </SystemTitleContainer>
-      <div css={css`text-transform: uppercase; font-size: 0.8rem; font-weight: 600; padding: 0.3rem 0rem;`}>
+      <div
+        css={css`
+          text-transform: uppercase;
+          font-size: 0.8rem;
+          font-weight: 600;
+          padding: 0.3rem 0rem;
+        `}
+      >
         Configuration(s):
       </div>
       {configs.map((c) => (
@@ -129,7 +133,14 @@ const SystemConfigs = ({
           removeConfig={removeConfig}
         />
       ))}
-      <TextButton css={css`padding-left:0rem; padding-bottom: 1.5rem; font-size: 1rem;`}onClick={() => addConfig(template)}>
+      <TextButton
+        css={css`
+          padding-left: 0rem;
+          padding-bottom: 1.5rem;
+          font-size: 1rem;
+        `}
+        onClick={() => addConfig(template)}
+      >
         + Add Configuration
       </TextButton>
     </SystemConfigsContainer>
@@ -197,8 +208,17 @@ const Config = ({ config, template, removeConfig }: ConfigProps) => {
         <SlideOut config={config} template={template} />
       </ConfigNameEditContainer>
       <TextButton
-        css={inHover ? css`visibility: visible;` : css`visibility: hidden;`}
-        onClick={() => removeConfig(config)}>
+        css={
+          inHover
+            ? css`
+                visibility: visible;
+              `
+            : css`
+                visibility: hidden;
+              `
+        }
+        onClick={() => removeConfig(config)}
+      >
         X
       </TextButton>
     </ConfigContainer>
@@ -216,7 +236,7 @@ const ConfigNameEditContainer = styled.div`
   width: 100%;
   padding: 0.5rem 0.9rem;
   align-items: center;
-`
+`;
 
 const ConfigContainer = styled.div`
   display: flex;

--- a/client/src/components/steps/Details.tsx
+++ b/client/src/components/steps/Details.tsx
@@ -1,18 +1,9 @@
 import { Fragment, useState } from "react";
 import { useStore } from "../../store/store";
-import Sidebarlayout from "../layouts/SidebarLayout";
 import EditDetailsModal from "../modal/EditDetailsModal";
-import LeftNav from "../LeftNavigation";
+import PageHeader from "../PageHeader";
 
-const Details = () => (
-  <Sidebarlayout
-    heading="Project Details"
-    contentLeft={<LeftNav />}
-    contentRight={<ContentRight />}
-  />
-);
-
-const ContentRight = () => {
+function Details() {
   const projectDetails = useStore(
     (state) => state.getActiveProject().projectDetails,
   );
@@ -21,6 +12,8 @@ const ContentRight = () => {
 
   return (
     <Fragment>
+      <PageHeader headerText="Project Details" />
+
       <h2 className="flex-space-between">
         {projectDetails.name}
 
@@ -73,6 +66,6 @@ const ContentRight = () => {
       </ul>
     </Fragment>
   );
-};
+}
 
 export default Details;

--- a/client/src/components/steps/Quantities.tsx
+++ b/client/src/components/steps/Quantities.tsx
@@ -1,12 +1,13 @@
-import Sidebarlayout from "../layouts/SidebarLayout";
+import { Fragment } from "react";
+import PageHeader from "../PageHeader";
 
-// step 4
-const Quantities = () => (
-  <Sidebarlayout
-    heading="Quantities"
-    contentLeft={<p>hello</p>}
-    contentRight={<p>world</p>}
-  />
-);
+function Quantities() {
+  return (
+    <Fragment>
+      <PageHeader headerText="Quantities" />
+      <p>world</p>;
+    </Fragment>
+  );
+}
 
 export default Quantities;

--- a/client/src/components/steps/Results.tsx
+++ b/client/src/components/steps/Results.tsx
@@ -1,12 +1,13 @@
-import Sidebarlayout from "../layouts/SidebarLayout";
+import { Fragment } from "react";
+import PageHeader from "../PageHeader";
 
-// step 6
-const Results = () => (
-  <Sidebarlayout
-    heading="Results"
-    contentLeft={<p>hello</p>}
-    contentRight={<p>world</p>}
-  />
-);
+function Results() {
+  return (
+    <Fragment>
+      <PageHeader headerText="Results" />
+      <p>world</p>;
+    </Fragment>
+  );
+}
 
 export default Results;

--- a/client/src/components/steps/Schedules.tsx
+++ b/client/src/components/steps/Schedules.tsx
@@ -1,12 +1,13 @@
-import Sidebarlayout from "../layouts/SidebarLayout";
+import { Fragment } from "react";
+import PageHeader from "../PageHeader";
 
-// step 5
-const Schedules = () => (
-  <Sidebarlayout
-    heading="Equipment Schedules"
-    contentLeft={<p>hello</p>}
-    contentRight={<p>world</p>}
-  />
-);
+function Schedules() {
+  return (
+    <Fragment>
+      <PageHeader headerText="Schedules" />
+      <p>world</p>;
+    </Fragment>
+  );
+}
 
 export default Schedules;

--- a/client/src/components/steps/Systems.tsx
+++ b/client/src/components/steps/Systems.tsx
@@ -1,20 +1,11 @@
 import { Fragment } from "react";
 import styled from "@emotion/styled";
-
+import PageHeader from "../PageHeader";
 import { useStore, SystemTemplate, SystemType } from "../../store/store";
 
-import Sidebarlayout from "../layouts/SidebarLayout";
-import LeftNav from "../LeftNavigation";
 // step 2
-const Systems = () => (
-  <Sidebarlayout
-    heading="Add Systems"
-    contentLeft={<LeftNav />}
-    contentRight={<ContentRight />}
-  />
-);
 
-const ContentRight = () => {
+const Systems = () => {
   const { getTemplates, systemTypes } = useStore((state) => ({
     getTemplates: state.getTemplates,
     systemTypes: state.systemTypes,
@@ -24,11 +15,9 @@ const ContentRight = () => {
 
   return (
     <Fragment>
+      <PageHeader headerText="Systems" />
       <div>Select the systems types you will configure:</div>
-      <TemplateGroupList
-        systemTypes={systemTypes}
-        templates={templates}
-      />
+      <TemplateGroupList systemTypes={systemTypes} templates={templates} />
     </Fragment>
   );
 };
@@ -44,14 +33,18 @@ const TemplateGroupList = ({
 }: TemplateGroupListProps) => {
   const getActiveTemplates = useStore((state) => state.getActiveTemplates);
   const addConfig = useStore((state) => state.addConfig);
-  const removeAllTemplateConfigs = useStore((state) => state.removeAllTemplateConfigs);
+  const removeAllTemplateConfigs = useStore(
+    (state) => state.removeAllTemplateConfigs,
+  );
 
   const activeTemplates = getActiveTemplates();
 
   const handler = (selection: string, value: boolean) => {
     const system = templates.find((s) => s.name === selection);
     if (system) {
-      value ? addConfig(system, {name: 'Default'}) : removeAllTemplateConfigs(system);
+      value
+        ? addConfig(system, { name: "Default" })
+        : removeAllTemplateConfigs(system);
     }
   };
 


### PR DESCRIPTION
### Description
sidebar nav re-renderd on each page change, this puts the `<SidebarLayout>` component at the root in `<App>` with a prop for if to show fullscreen or not. 

> later, we can expose this to toggle the schedules page fullscreen if the user needs more real estate to edit the table


### Testing
open a system in the left nav, then navigate between pages, your state should persist and should not re-render loosing the user's current state in the `<LeftNav>` component
