### PR TITLE
DK/store list sorting

### DIFF
--- a/client/src/store/store.test.ts
+++ b/client/src/store/store.test.ts
@@ -61,6 +61,23 @@ test("Adding configs adds active system templates", () => {
   expect(activeTemplates.length).toEqual(2);
 });
 
+test("Active templates are returned alphabetized by name", () => {
+  const templates = useStore.getState().getTemplates();
+
+  const [t1, t2, ..._rest] = templates;
+  useStore.getState().addConfig(t1);
+  useStore.getState().addConfig(t2);
+  const activeTemplates = useStore.getState().getActiveTemplates();
+  const alphabetizedNames = activeTemplates.map((t) => t.name).sort();
+  expect(activeTemplates.map((t) => t.name)).toEqual(alphabetizedNames);
+
+  const notSortedActiveTemplates = useStore.getState().getActiveTemplates(null);
+
+  expect(activeTemplates.map((t) => t.name)).not.toEqual(
+    notSortedActiveTemplates.map((t) => t.name),
+  );
+});
+
 test("Template/Option Denormalization", () => {
   const [templateN, ...templatesN] = useStore.getState().templates;
   const template = useStore


### PR DESCRIPTION
### Description
Adds a `sort` optional arg that can be provided to store list gets. For certain lists there is a default sort implemented. If 'null' is provided, the list is returned in declaration order.

### Testing
A test has been added to FE tests to 
