### PR TITLE
dk/frontend schema tracking

### DIFF
--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -1,5 +1,7 @@
 /**
  * Store for linkage widget
+ *
+ * If there are any updates to the store schema increment SCHEMA_VERSION
  */
 
 import create, { SetState, GetState } from "zustand";
@@ -10,6 +12,8 @@ import uiSlice, { uiSliceInterface } from "./slices/ui-slice";
 import userSlice, { UserSliceInterface } from "./slices/user-slice";
 
 export * from "./slices/user-slice";
+
+const SCHEMA_VERSION = 1;
 
 export interface SystemType {
   id: number;
@@ -139,6 +143,7 @@ export const useStore = create<State>(
     }),
     {
       name: "linkage-storage",
+      version: SCHEMA_VERSION,
     },
   ),
 );


### PR DESCRIPTION
### Description
Starts using the 'persist' middleware's 'version' option. When the version changes, the store is cleared of any entries.

### Testing
* Serve the front end locally (`npm run start`)
* Open up chrome devtools to look at what is currently stored in local storage
* Update the schema version in `store.ts` and save
* The front end should reload with all previous selections removed
