### PR TITLE
zoom in on scroll to the results image

### DIFF
--- a/client/src/components/steps/Results/ImgControl.tsx
+++ b/client/src/components/steps/Results/ImgControl.tsx
@@ -1,15 +1,39 @@
 import schematic from "./schematics-example.png";
-import { Fragment } from "react";
+import { Fragment, useEffect, useState, createRef } from "react";
 import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 
 function ImgControl() {
+  const $root = createRef<HTMLDivElement>();
+
+  const [height, setHeight] = useState(0);
+
+  useEffect(() => {
+    function calcHeight() {
+      const $el = $root.current;
+      if (!$el) return;
+      const top = $el.getBoundingClientRect().top || 0;
+      setHeight(window.innerHeight - top - 80);
+      console.log("resized");
+    }
+
+    window.addEventListener("resize", calcHeight);
+    calcHeight();
+
+    return () => {
+      window.removeEventListener("resize", calcHeight);
+    };
+  });
+
   return (
-    <div className="drag-container">
+    <div
+      ref={$root}
+      style={{ height: `${height}px` }}
+      className="drag-container"
+    >
       <TransformWrapper
         initialScale={1}
         initialPositionX={0}
         initialPositionY={0}
-        wheel={{ disabled: true }}
       >
         {({ zoomIn, zoomOut, resetTransform }) => (
           <Fragment>

--- a/client/src/styles/steps/results.scss
+++ b/client/src/styles/steps/results.scss
@@ -1,6 +1,6 @@
 .results-page {
   margin: calc(var(--spacing-lg) * -1);
-  height: 100%;
+  box-sizing: border-box;
 
   nav.tab-list {
     background-color: var(--color-blue-x-light);
@@ -30,7 +30,7 @@
     display: block;
     overflow: hidden;
     user-select: none;
-    height: 100%;
+    overflow: hidden;
 
     .controls {
       z-index: 3;


### PR DESCRIPTION
### Description
add back in the ability to scroll zoom in and out of the results SVG
This requires some height calculation in order for the page to never scroll, and take up all of the height available on the screen.
