### PR TITLE
# 126 child option formatting

### DIFF
--- a/server/src/parser/parser.ts
+++ b/server/src/parser/parser.ts
@@ -125,16 +125,25 @@ export class InputGroup extends Element {
   }
 
   getOptions(recursive = true) {
+    // A group with no elementList is ignorecd
+    if (this.elementList.length === 0) {
+      return {};
+    }
+
+    const children = this.elementList.filter(
+      (el) => Object.keys(el.getOptions()).length > 0,
+    );
+
     const option: OptionN = {
       modelicaPath: this.modelicaPath,
       type: this.type,
       name: this.description,
-      options: this.elementList.map((el) => el.modelicaPath)
+      options: children.map((c) => c.modelicaPath),
     };
 
     let options: { [key: string]: OptionN } = { [option.modelicaPath]: option };
 
-    this.elementList.map((el) => {
+    children.map((el) => {
       options = { ...options, ...el.getOptions(recursive) };
     });
 
@@ -250,7 +259,7 @@ export class Input extends Element {
       tab: this.tab,
       valueExpression: this.valueExpression,
       enable: this.enable,
-      final: this.final
+      final: this.final,
     };
 
     let options = { [option.modelicaPath]: option };
@@ -438,14 +447,21 @@ export class InputGroupExtend extends Element {
 
   getOptions(recursive = true) {
     const typeInstance = typeStore.get(this.type) as Element;
+
     if (typeInstance) {
+      const childOptions = Object.keys(typeInstance.getOptions(false));
+      if (childOptions.length === 0) {
+        return {};
+      }
+
       const option: OptionN = {
         modelicaPath: this.modelicaPath,
         type: this.type,
         value: this.value,
         name: typeInstance.name,
-        options: Object.keys(typeInstance.getOptions(false)),
+        options: [this.type],
       };
+
       return {
         ...{ [option.modelicaPath]: option },
         ...typeInstance.getOptions(recursive),

--- a/server/tests/integration/parser/parsed-elements.test.ts
+++ b/server/tests/integration/parser/parsed-elements.test.ts
@@ -146,14 +146,14 @@ describe("Expected Options are extracted", () => {
     expect(selectable?.group).toEqual(selectableGroup);
   });
 
-  it("Ignore 'final' parameters", () => {
+  it("Set 'final' parameter correctly", () => {
     const file = parser.getFile(testModelicaFile) as parser.File;
     const template = file.elementList[0] as parser.InputGroup;
 
     const options = template.getOptions();
     const option = options["TestPackage.Template.TestTemplate.should_ignore"];
 
-    expect(option).toBeUndefined();
+    expect(option.final).toBeTruthy();
   });
 
   it("Enums return each type as an option", () => {
@@ -175,7 +175,7 @@ describe("Expected Options are extracted", () => {
   });
 
   it("Extracts the expected number of options for the TestTemplate", () => {
-    const optionTotal = 39;
+    const optionTotal = 41;
     const file = parser.getFile(testModelicaFile) as parser.File;
     const template = file.elementList[0] as parser.InputGroup;
     const options = template.getOptions();

--- a/server/tests/integration/parser/template.test.ts
+++ b/server/tests/integration/parser/template.test.ts
@@ -40,7 +40,7 @@ describe("Basic parser functionality", () => {
   it("Templates output expected linkage schema for SystemTemplates", () => {
     const expectedTemplateValues = {
       modelicaPath: "TestPackage.Template.TestTemplate",
-      optionLength: 39,
+      optionLength: 41,
       systemTypeLength: 1,
     };
 


### PR DESCRIPTION
### Description
Fixes bugs around how child options are assigned including: 

- 'extend' clauses were not getting child options assigned
- InputGroups that do not have child options do not generate an option

Changes how 'final' is treated:
- Previously a 'final' parameter would generate no option. This was not going to work as a 'final' parameter may be a component that has child parameters that are NOT final. Filtering out this option would prevent fetching those settable child options.
- OptionN options now have a 'final' parameter that gets set to true when 'final' is present.

### Related Issue(s)
#126

### Testing
Run integration tests.
