### PR TITLE
Fix container modelica path

### DIFF
--- a/server/docker/docker-compose.yaml
+++ b/server/docker/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     env_file:
       - ../.env
     environment:
-      - MODELICAPATH=/app/dependencies/ModelicaStandardLibrary:/app/dependencies/modelica-buildings
+      - MODELICAPATH=/dependencies/ModelicaStandardLibrary:/dependencies/modelica-buildings
     ports:
       - ${PORT:-3000}:${PORT:-3000}
     volumes:


### PR DESCRIPTION
### Description
Fixes an error with `MODELICAPATH` setup for the container.

### Testing
First, stop and rebuild the container:

```
cd server
npm run docker:stop
npm run docker:start
```

In the container, navigate to the modelica-json tool, and use it to convert the templates folder.

```
npm run docker:shell
# now in the container
cd /dependencies/modelica-json
node app.js -f Buildings/Templates -o json -d out
```

This command should succeed, and if you check the contents of:

`/dependencies/modelica-json/out/json` you should see a `Buildings` and `Modelica` directories.