### PR TITLE
Add root docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,62 @@
+version: "2"
+
+services:
+  nginx-proxy:
+    image: nginxproxy/nginx-proxy
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - conf:/etc/nginx/conf.d
+      - vhost:/etc/nginx/vhost.d
+      - html:/usr/share/nginx/html
+      - certs:/etc/nginx/certs:ro
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+
+  acme-companion:
+    image: nginxproxy/acme-companion
+    volumes_from:
+      - nginx-proxy
+    volumes:
+      - certs:/etc/nginx/certs:rw
+      - acme:/etc/acme.sh
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+
+  client:
+    image: node
+    expose:
+      - 3000
+    command: "npm run start"
+    working_dir: "/home/node/app"
+    volumes:
+      - "./client:/home/node/app"
+    environment:
+      - VIRTUAL_HOST=ec2-52-35-179-192.us-west-2.compute.amazonaws.com
+      - LETSENCRYPT_HOST=ec2-52-35-179-192.us-west-2.compute.amazonaws.com
+      - VIRTUAL_PATH=/
+    env_file:
+      - ./client/.env
+
+  server:
+    build:
+      context: ./server
+      dockerfile: ./docker/Dockerfile
+    expose:
+      - 3000
+    environment:
+      - VIRTUAL_HOST=ec2-52-35-179-192.us-west-2.compute.amazonaws.com
+      - LETSENCRYPT_HOST=ec2-52-35-179-192.us-west-2.compute.amazonaws.com
+      - VIRTUAL_PATH=/api
+      - MODELICAPATH=/dependencies/ModelicaStandardLibrary:/dependencies/modelica-buildings
+    command: npm run start
+    env_file:
+      - ./server/.env
+    volumes:
+      - ./server:/app
+
+volumes:
+  conf:
+  vhost:
+  html:
+  certs:
+  acme:


### PR DESCRIPTION
### Description
Adds the root docker-compose.yml powering the staging server. This environment provisions:
- an nginx reverse proxy
- an acme-companion to auto-generate letsencrypt certificates (enable https) once we have DNS setup
- client app (running react dev server)
- server app

### Related Issue(s)
https://github.com/devetry/LBL-Linkage-Widget-v2/issues/165

### Testing
This will probably build locally, but you won't be able to get to it. Testing is that http://ec2-52-35-179-192.us-west-2.compute.amazonaws.com works as expected
