### PR TITLE
added modifiers to the config front end options

### DIFF
--- a/client/src/components/steps/Configs/SlideOut.tsx
+++ b/client/src/components/steps/Configs/SlideOut.tsx
@@ -20,6 +20,7 @@ export interface FlatConfigOption {
   parentName: string;
   modelicaPath: string;
   name: string;
+  modifiers: any;
   choices?: OptionInterface[];
 }
 
@@ -37,19 +38,48 @@ export interface ConfigSlideOutProps {
   close: () => void;
 }
 
+// TODO: Create Modifiers interface shape
+
 // Provides a flat array of options for display. This approach avoids processing the data structure in the return statement of components and keeps the logic related to the data separate from the logic that drives how components work.
 export function flattenConfigOptions(
   optionsToFlatten: OptionInterface[],
   parentModelicaPath: string,
   parentName: string,
+  modifiers: any,
   selectedOptions?: SelectedConfigOptions,
 ): FlatConfigOption[] {
   let flatConfigOptions: FlatConfigOption[] = [];
+  let flatConfigModifiers: any = modifiers;
   optionsToFlatten.forEach((option) => {
     // Ignores paths that finish in .dat
     // TODO: Make sure we exclude only .dat at the end of the string thanks to regular expression
     if (option.modelicaPath.includes(`.dat`)) {
       return;
+    }
+
+    // Setting up newChildren if the visiblity needs to be modified
+    const newChildOptions: OptionInterface[] = [];
+
+    // Creating a flatten object of modifiers to modify children's visiblity if modifiers exist
+    if (option.modifiers && Object.keys(option.modifiers).length !== 0) {
+      flatConfigModifiers = {
+        ...flatConfigModifiers,
+        ...option.modifiers,
+      };
+    }
+
+    // If we have an object of flattened Modifiers and we have children we need to modify those children's visiblilty
+    // if there is a modifier for the child
+    if (Object.keys(flatConfigModifiers).length !== 0 && option.childOptions?.length) {
+      option.childOptions.forEach((child: any) => {
+        const newChild: OptionInterface = {...child};
+        const childModifier: any = flatConfigModifiers[child.modelicaPath];
+
+        if (childModifier && childModifier?.final !== undefined) {
+          newChild.visible = child?.visible && !childModifier.final;
+        }
+        newChildOptions.push(newChild);
+      });
     }
 
     if (option.visible && option.childOptions?.length) {
@@ -61,7 +91,8 @@ export function flattenConfigOptions(
           parentName,
           modelicaPath: option.modelicaPath,
           name: option.name,
-          choices: option.childOptions,
+          modifiers: flatConfigModifiers,
+          choices: newChildOptions.length ? newChildOptions : option.childOptions,
         },
       ];
 
@@ -79,9 +110,10 @@ export function flattenConfigOptions(
       flatConfigOptions = [
         ...flatConfigOptions,
         ...flattenConfigOptions(
-          option.childOptions,
+          newChildOptions.length ? newChildOptions : option.childOptions,
           option.modelicaPath,
           option.name,
+          flatConfigModifiers,
           selectedOptions,
         ),
       ];
@@ -142,13 +174,15 @@ const SlideOut = ({ configId, close }: ConfigSlideOutProps) => {
     }
 
     // If no saved selection found, returns first choice of the option if any
-    return option.choices?.[0];
+    // return option.choices?.[0];
+    // TODO: Display default option of blank
+    return undefined;
   }
 
   // Looks up the store to make sure that the UI takes into consideration the choices selected by the user previously or first choices if nothing was selected
   function getInitialSelection() {
     let initialSelection = {};
-    const flatConfigOptions = flattenConfigOptions(options, "root", "");
+    const flatConfigOptions = flattenConfigOptions(options, "root", "", {});
     flatConfigOptions.forEach((option) => {
       const savedOptionSelection = getSavedConfigOption(option);
       if (savedOptionSelection) {
@@ -156,6 +190,7 @@ const SlideOut = ({ configId, close }: ConfigSlideOutProps) => {
           [savedOptionSelection],
           option.modelicaPath,
           option.name,
+          option.modifiers
         );
         if (flatChildOptions.length > 0) {
           initialSelection = {
@@ -177,6 +212,7 @@ const SlideOut = ({ configId, close }: ConfigSlideOutProps) => {
     options,
     "root",
     "",
+    {},
     selectedOptions,
   );
 
@@ -192,6 +228,7 @@ const SlideOut = ({ configId, close }: ConfigSlideOutProps) => {
       [option],
       parentModelicaPath,
       parentName,
+      {}
     );
 
     setSelectedOptions({


### PR DESCRIPTION
### Description
This adds the child options modifier functionality to the frontend. This checks if a child option has a modifier and applies the appropriate visibility flag for that child option based on the modifier. 

### Related Issue(s)
 #96

### Testing
A new `templates.json` file will need to be generated and moved to the `client/src/data` directory. Once it is generated the config options should be greatly reduced due to the modifiers.

Steps to generate a new templates.json:

1. Start up the server in a container.
2. Update Directory location for the templates.json creation. `server/scripts/parse-template-package.ts` `${__dirname}/templates.json`
3. Generate the templates.json file with the following script: npm run parseTemplateJSON
4. Copy the templates.json to the `client/src/data` directory.
View the config page in a browser.
 