### PR TITLE
Dk/fix replaceable enable set

### DIFF
--- a/server/src/parser/parser.ts
+++ b/server/src/parser/parser.ts
@@ -470,7 +470,7 @@ export class Input extends Element {
         ? evaluateExpression(connectorSizing)
         : false;
     } else {
-      this.enable = isInputGroupType ? this.enable : true;
+      this.enable = isInputGroupType && !isReplaceable ? this.enable : true;
     }
   }
 

--- a/server/tests/integration/parser/parsed-elements.test.ts
+++ b/server/tests/integration/parser/parsed-elements.test.ts
@@ -143,14 +143,6 @@ describe("Expected Inputs are extracted", () => {
     expect(input?.group).toEqual(expectedGroup);
     expect(input?.tab).toEqual(expectedTab);
     expect(input?.enable).not.toBeFalsy();
-
-    // also test a "constrainedby" component as this impacts where the annotation
-    // is placed
-    const selectablePath =
-      "TestPackage.Template.TestTemplate.selectable_component";
-    const selectableGroup = "Selectable Component";
-    const selectable = inputs[selectablePath];
-    expect(selectable?.group).toEqual(selectableGroup);
   });
 
   it("Set 'visible' parameter correctly", () => {
@@ -231,5 +223,13 @@ describe("Expected Inputs are extracted", () => {
       }
     });
     // console.log(inputCount);
+  });
+
+  it("Replaceable 'enable' field is set as expected", () => {
+    const file = parser.getFile(testModelicaFile) as parser.File;
+    const template = file.elementList[0] as parser.InputGroup;
+    const replaceableInput = template.getInputs()['TestPackage.Template.TestTemplate.selectable_component'];
+
+    expect(replaceableInput.enable).toBeTruthy();
   });
 });


### PR DESCRIPTION
### Description
Updates how the enable flag is set for 'Input' types and child types (`ReplaceableInput`). Replaceable inputs were being incorrectly treated as normal class instances.

### Testing
Integration tests have been updated to cover this case.
