### PR TITLE
Remove default modifier when mapping from template input to option

### DIFF
--- a/server/tests/integration/parser/modifiers.test.ts
+++ b/server/tests/integration/parser/modifiers.test.ts
@@ -115,4 +115,12 @@ describe("Modifications", () => {
     expect(mod.final).toBeTruthy();
     expect(evaluateExpression(mod.expression)).toEqual('TestPackage.Component.SecondComponent');
   });
+
+  it("Doesn't have a modifier that matches the option path (the 'default mod')", () => {
+    const path = "TestPackage.Template.TestTemplate.typ";
+    const option = tOptions[path];
+    const mod = option.modifiers[path];
+  
+    expect(mod).toBeUndefined();
+  });
 });


### PR DESCRIPTION
### Description
Makes sure that the 'default modifier' (the value assigned to any given parameter) is not included in the dictionary of modifiers listed on the option.

### Testing
A modification integration test has been added. Make sure tests pass.