### PR TITLE
fixes empty groups

### DIFF
--- a/client/src/components/steps/Configs/SlideOut.tsx
+++ b/client/src/components/steps/Configs/SlideOut.tsx
@@ -295,7 +295,7 @@ const SlideOut = ({
             ),
           ];
         }
-      } else if (option.definition && option.childOptions?.length && parentModelicaPath !== 'root') {
+      } else if (option.definition && option.childOptions?.length) {
         displayOptions = [
           ...displayOptions,
           {
@@ -309,6 +309,12 @@ const SlideOut = ({
             ),
           }
         ];
+        if ('groupName' in displayOptions[displayOptions.length-1]) {
+          const optionGroup = displayOptions[displayOptions.length-1] as FlatConfigOptionGroup;
+          if (!optionGroup.items.length) {
+            displayOptions.pop();
+          }
+        }
       } else if (option.childOptions?.length) {
         displayOptions = [
           ...displayOptions,
@@ -363,8 +369,6 @@ const SlideOut = ({
 
       if ('groupName' in option) {
         const optionGroup = option as FlatConfigOptionGroup;
-
-        if (!optionGroup.items.length) return null;
 
         return (
           <div className="display-group-container" key={optionGroup.selectionPath}>


### PR DESCRIPTION
### Description
This PR fixes the display of empty groups of options. This also adds the main group as well.

### Related Issue(s)
#100 #138 

### Testing
You shouldn't see groups with no children groups or options when you open the slide out and change a selection.
