### PR TITLE
Values added to config store

### DIFF
--- a/client/src/components/steps/Configs/Config.tsx
+++ b/client/src/components/steps/Configs/Config.tsx
@@ -3,11 +3,11 @@ import { useDebouncedCallback } from "use-debounce";
 import { observer } from "mobx-react";
 
 import SlideOutOpenButton from "./SlideOutOpenButton";
-import SlideOut, { ConfigValues } from "./SlideOut";
+import SlideOut from "./SlideOut";
 import { useStores } from "../../../data";
 
 import { OptionInterface, TemplateInterface } from "../../../data/template";
-import { Modifiers } from "../../../utils/modifier-helpers";
+import { Modifiers, ConfigValues } from "../../../utils/modifier-helpers";
 import { ConfigInterface } from "../../../data/config";
 
 export interface ConfigProps {
@@ -29,6 +29,8 @@ const Config = observer(({ configId }: ConfigProps) => {
   const allOptions: { [key: string]: OptionInterface } =
     templateStore.getAllOptions();
 
+  const [openedModal, setOpenedModal] = useState(false);
+
   function removeConfiguration(event: MouseEvent) {
     event.preventDefault();
     configStore.remove(configId);
@@ -41,7 +43,6 @@ const Config = observer(({ configId }: ConfigProps) => {
     400,
   );
 
-  const [openedModal, setOpenedModal] = useState(false);
   function openModal() {
     setOpenedModal(true);
     uiStore.setOpenSystemPath(config.systemPath);

--- a/client/src/data/config.ts
+++ b/client/src/data/config.ts
@@ -3,6 +3,8 @@ import { makeAutoObservable, toJS } from "mobx";
 import { makePersistable } from "mobx-persist-store";
 import RootStore from "./index";
 
+import { ConfigValues } from "../utils/modifier-helpers";
+
 export interface SelectionInterface {
   name: string;
   value: string;
@@ -12,11 +14,12 @@ export interface ConfigInterface {
   id: string;
   name?: string;
   isLocked: boolean;
-  selections?: SelectionInterface[];
+  selections?: ConfigValues;
+  evaluatedValues?: ConfigValues;
   quantity?: number;
   systemPath: string;
   templatePath: string;
-  [key: string]: string | number | undefined | boolean | SelectionInterface[];
+  [key: string]: string | number | undefined | boolean | ConfigValues;
 }
 
 export type ConfigProps = Omit<ConfigInterface, "id">;
@@ -41,7 +44,8 @@ export default class Config {
       id: uuid(),
       name: "Default",
       isLocked: false,
-      selections: [] as SelectionInterface[],
+      selections: {},
+      evaluatedValues: {},
       quantity: 1,
 
       ...config,
@@ -79,26 +83,32 @@ export default class Config {
   }
 
   // Look in the config for the value of the first option that matches a given modelicaPath
-  findOptionValue(configId: string, optionPath: string): string | undefined {
-    const config = this.getById(configId);
-    if (!config?.selections) return undefined;
+  // findOptionValue(configId: string, optionPath: string): string | undefined {
+  //   const config = this.getById(configId);
+  //   if (!config?.selections) return undefined;
 
-    return config.selections.find((selection) => selection.name === optionPath)
-      ?.value;
-  }
+  //   return config.selections.find((selection) => selection.name === optionPath)
+  //     ?.value;
+  // }
 
-  setSelections(configId: string, selections: SelectionInterface[]) {
+  setSelections(configId: string, selections: ConfigValues) {
     const config = this.getById(configId);
     if (config) config.selections = selections;
   }
 
+  setEvaluatedValues(configId: string, evaluatedValues: ConfigValues) {
+    const config = this.getById(configId);
+    if (config) config.evaluatedValues = evaluatedValues;
+  }
+
   getConfigSelections(configId: string | undefined): any {
     const config = this.getById(configId);
-    const selections = config?.selections?.reduce(
-      (obj, selection) => ({ ...obj, [selection.name]: selection.value }),
-      {},
-    );
-    return toJS(selections || {});
+    return config?.selections;
+  }
+
+  getConfigEvaluatedValues(configId: string | undefined): any {
+    const config = this.getById(configId);
+    return config?.evaluatedValues;
   }
 
   getActiveConfigs(): ConfigInterface[] {

--- a/client/src/utils/utils.ts
+++ b/client/src/utils/utils.ts
@@ -31,3 +31,9 @@ export const sortByName = (a: SortableByName, b: SortableByName): number =>
 
 export const trace = (target: any): any =>
   console.log(JSON.parse(JSON.stringify(target)));
+
+export function removeEmpty(obj: any) {
+  return Object.entries(obj)
+    .filter(([_, v]) => v != null)
+    .reduce((acc, [k, v]) => ({ ...acc, [k]: v }), {});
+}


### PR DESCRIPTION
### Description
This PR takes the selections, evaluated values, and config name from the config page form and saves them to the config store. 

This also added a utility to remove key's we null values.

### Related Issue(s)
#239 

### Testing
Tests coming to the frontend soon.
