### PR TITLE
initial pass of configs to seq doc

### DIFF
--- a/client/src/components/modal/DownloadModal.tsx
+++ b/client/src/components/modal/DownloadModal.tsx
@@ -1,6 +1,8 @@
 import Modal, { ModalInterface } from "./Modal";
 import { useState, ChangeEvent } from "react";
 import itl from "../../translations";
+import { useStores } from "../../data";
+import { ConfigInterface } from "../../data/config";
 
 const CONTROL_SEQUENCE = "Control Sequence";
 const DOCX = "docx";
@@ -15,9 +17,12 @@ const DOWNLOADABLE_FILE_LIST = [
 ];
 
 function DownloadModal({ isOpen, close }: ModalInterface) {
+  const { configStore } = useStores();
   const [checked, setChecked] = useState(
     DOWNLOADABLE_FILE_LIST.map(({ label }) => label),
   );
+
+  const projectConfigs: ConfigInterface[] = configStore.getConfigsForProject();
 
   function updateItem(event: ChangeEvent<HTMLInputElement>, label: string) {
     if (event.target.checked) {
@@ -33,11 +38,8 @@ function DownloadModal({ isOpen, close }: ModalInterface) {
       const response = await fetch(`${process.env.REACT_APP_API}/sequence`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        // TODO: Replace with actual parameters necessary to generate the document
-        body: JSON.stringify({
-          optional: false,
-          dual_inlet_airflow_sensors: "yes",
-        }),
+        // TODO: Simplify Data to pass to the backend
+        body: JSON.stringify(projectConfigs),
       });
 
       // TODO: Handle error responses which do not contain an actual file

--- a/client/src/data/config.ts
+++ b/client/src/data/config.ts
@@ -128,6 +128,16 @@ export default class Config {
     );
   }
 
+  getConfigsForProject(
+    //TODO: need to connect project to configs
+    //projectId: string,
+  ): ConfigInterface[] {
+    return toJS(this.configs);
+    /*return this.configs.filter(
+      (config) => config.projectId === projectId
+    );*/
+  }
+
   removeAllForSystemTemplate(systemPath: string, templatePath: string) {
     this.configs = this.configs.filter((config) =>
       config.systemPath === systemPath && config.templatePath === templatePath

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -95,6 +95,8 @@ app.post("/api/sequence", async (req, res) => {
   // The Control Sequence Input consists of mock data at the moment.
   // Please note that this is a very naive data format.
   // The shape of this object will most likely need to be modified and massaged when we work with real data.
+  const request = req.body;
+  console.log('request: ', request);
   const controlSequenceInput: ControlSequenceInput = {
     energyCode: EnergyCode.Ashrae,
     choices: {


### PR DESCRIPTION
### Description
This PR grabs all the configs and passes them to the sequence document api.

Notes: 

- Currently projects and configs are not connected, this will need to be wired up when multiple projects can exist at a time.
- The amount of data being sent to the sequence document api can be simplified and this will happen once we figure out what all is needed when working with the sequence document.

### Related Issue(s)
#239 

### Testing
Tests are coming to the frontend
