### PR TITLE
Use linkage keyword when setting parameter 'enable' value

### DIFF
--- a/server/tests/integration/parser/parsed-elements.test.ts
+++ b/server/tests/integration/parser/parsed-elements.test.ts
@@ -235,4 +235,21 @@ describe("Expected Inputs are extracted", () => {
 
     expect(replaceableInput.enable).toBeTruthy();
   });
+
+  it("Linkage Keyword overrides enable logic", () => {
+    const file = parser.getFile(testModelicaFile) as parser.File;
+    const template = file.elementList[0] as parser.InputGroup;
+    const templateInputs = template.getInputs();
+    const forcedTrue = templateInputs[
+      "TestPackage.Template.TestTemplate.linkage_keyword_true"
+    ];
+
+    const forcedFalse = templateInputs[
+      "TestPackage.Template.TestTemplate.linkage_keyword_false"
+    ];
+
+
+    expect(forcedTrue.enable).toBeTruthy();   
+    expect(forcedFalse.enable).toBeFalsy(); 
+  });
 });

--- a/server/tests/static-data/TestPackage/Template/TestTemplate.mo
+++ b/server/tests/static-data/TestPackage/Template/TestTemplate.mo
@@ -107,9 +107,19 @@ model TestTemplate "Test Template"
 
   // enable condition: 'connectorSizing=false'
   parameter Integer connector_param_false
-    "Connector Param with 'connectorSizing=false'"
+    "Param with connectorSizing"
     annotation (Dialog(connectorSizing=false));
   // END DISABLE CONDITIONS
+
+  // Linkage keyword override - false to true
+  parameter Integer linkage_keyword_true
+    "Param to test linkage keyword override to true"
+    annotation (Dialog(connectorSizing=false), __Linkage(enable=true));
+
+  // Linkage keyword override - true to false
+  parameter Integer linkage_keyword_false
+    "Param to test linkage keyword override to false"
+    annotation (Dialog(enable=true), __Linkage(enable=false));
 
   parameter TestPackage.Types.IceCream typ = TestPackage.Types.IceCream.Chocolate
     "Test Enum"


### PR DESCRIPTION
### Description
All parameter types now check for the linkage keyword (e.g. `__Linkage(enable=false)`). This value now overrides any logic around 'enable' and 'disable' values.


### Testing
An integration test has been added.