### PR TITLE
Remove 'InfoboxList'

### DIFF
--- a/server/scripts/sequence-doc/src/mogrifier.py
+++ b/server/scripts/sequence-doc/src/mogrifier.py
@@ -212,11 +212,11 @@ def create_control_structures(doc):
 def remove_info_and_instr_boxes(doc, selections: Selections):
     ''' Removes info and instruction boxes
     '''
-    info_box_style = 'Info. box'
+    info_box_styles = ['Info. box', 'InfoboxList']
     instr_box_style = 'Instr. box'
 
     for para in doc.paragraphs:
-        if utils.reduce_to_boolean(selections['DEL_INFO_BOX']) and para.style.name == info_box_style:
+        if utils.reduce_to_boolean(selections['DEL_INFO_BOX']) and para.style.name in info_box_styles:
             remove_node(para)
         if para.style.name == instr_box_style:
             remove_node(para)


### PR DESCRIPTION
### Description
'InfoboxList' paragraphs were not getting added to the removal list. This makes sure that the process that deletes 'Info. box List'.

### Testing
Generate a document, open it up and check:
- no opening error
- 'InfoboxList' is not present as a style in the document