### PR TITLE
Dk/453 selection object

### DIFF
--- a/client/src/components/modal/EditDetailsModal.tsx
+++ b/client/src/components/modal/EditDetailsModal.tsx
@@ -9,12 +9,15 @@ import { FlatConfigOption } from "../steps/Configs/SlideOut";
 import OptionSelect from "../steps/Configs/OptionSelect";
 import { useDebouncedCallback } from "use-debounce";
 import { removeEmpty } from "../../utils/utils";
-import { SystemTypeInterface, TemplateInterface } from "../../data/types";
+import {
+  SystemTypeInterface,
+  TemplateInterface,
+  ConfigValues,
+} from "../../data/types";
 
 import {
   applyValueModifiers,
   applyVisibilityModifiers,
-  ConfigValues,
 } from "../../utils/modifier-helpers";
 
 interface EditDetailsModalProps extends ModalInterface {
@@ -124,9 +127,8 @@ const EditDetailsModal = observer(
           ];
 
           if (selectedValues[selectionPath]) {
-            const selectedOption = allOptions[
-              selectedValues[selectionPath]
-            ] as OptionInterface;
+            const selectedValue = selectedValues[selectionPath].value;
+            const selectedOption = allOptions[selectedValue] as OptionInterface;
 
             if (selectedOption) {
               displayOptions = [
@@ -135,8 +137,9 @@ const EditDetailsModal = observer(
               ];
             }
           } else if (evaluatedValues[selectionPath]) {
+            const selectedValue = evaluatedValues[selectionPath].value;
             const evaluatedOption = allOptions[
-              evaluatedValues[selectionPath]
+              selectedValue
             ] as OptionInterface;
 
             if (evaluatedOption) {
@@ -195,7 +198,7 @@ const EditDetailsModal = observer(
 
         return {
           ...prevState,
-          [selectionPath]: choice,
+          [selectionPath]: { value: choice },
         };
       });
     }
@@ -208,7 +211,7 @@ const EditDetailsModal = observer(
         projectSelectedItems["Buildings.Templates.Data.AllSystems.stdEne"];
 
       if (
-        energyStandard ===
+        energyStandard?.value ===
           "Buildings.Controls.OBC.ASHRAE.G36.Types.EnergyStandard.ASHRAE90_1" &&
         projectSelectedItems["Buildings.Templates.Data.AllSystems.tit24CliZon"]
       ) {
@@ -218,7 +221,7 @@ const EditDetailsModal = observer(
       }
 
       if (
-        energyStandard ===
+        energyStandard?.value ===
           "Buildings.Controls.OBC.ASHRAE.G36.Types.EnergyStandard.California_Title_24" &&
         projectSelectedItems["Buildings.Templates.Data.AllSystems.ashCliZon"]
       ) {

--- a/client/src/components/steps/Configs/Config.tsx
+++ b/client/src/components/steps/Configs/Config.tsx
@@ -7,7 +7,6 @@ import SlideOut from "./SlideOut";
 import { useStores } from "../../../data";
 
 import { OptionInterface, TemplateInterface } from "../../../data/types";
-import { ConfigValues } from "../../../utils/modifier-helpers";
 import { ConfigInterface } from "../../../data/config";
 import Spinner from "../../Spinner";
 
@@ -21,7 +20,7 @@ const Config = observer(({ configId }: ConfigProps) => {
   const template = templateStore.getTemplateByPath(
     config.templatePath,
   ) as TemplateInterface;
-  const selections: ConfigValues = configStore.getConfigSelections(configId);
+  const selections = configStore.getConfigSelections(configId);
   const allOptions: { [key: string]: OptionInterface } =
     templateStore.getAllOptions();
 

--- a/client/src/components/steps/Configs/SlideOut.tsx
+++ b/client/src/components/steps/Configs/SlideOut.tsx
@@ -5,8 +5,11 @@ import { useStores } from "../../../data";
 import { OptionInterface } from "../../../data/types";
 import Modal from "../../modal/Modal";
 import OptionSelect from "./OptionSelect";
-import { mapToDisplayOptions as mapConfigContextToDisplayOptions } from "../../../interpreter/display-option";
-import { ConfigContext, ConfigValues } from "../../../interpreter/interpreter";
+import {
+  mapToDisplayOptions as mapConfigContextToDisplayOptions,
+  createConfigContext,
+} from "../../../interpreter/display-option";
+import { ConfigValues } from "../../../data/types";
 import { removeEmpty } from "../../../utils/utils";
 
 import "../../../styles/components/config-slide-out.scss";
@@ -58,7 +61,7 @@ const SlideOut = ({
   });
   const [configName, setConfigName] = useState<string>(config.name);
 
-  const context = new ConfigContext(
+  const context = createConfigContext(
     template,
     config,
     allOptions,
@@ -92,7 +95,7 @@ const SlideOut = ({
 
       return {
         ...prevState,
-        [selectionPath]: choice,
+        [selectionPath]: { value: choice },
       };
     });
   }

--- a/client/src/data/config.ts
+++ b/client/src/data/config.ts
@@ -1,8 +1,7 @@
 import { v4 as uuid } from "uuid";
 import { toJS } from "mobx";
 import RootStore from "./index";
-
-import { ConfigValues } from "../utils/modifier-helpers";
+import { ConfigValues } from "./types";
 
 export interface SelectionInterface {
   name: string;

--- a/client/src/data/config.ts
+++ b/client/src/data/config.ts
@@ -92,9 +92,9 @@ export default class Config {
     if (config) config.evaluatedValues = evaluatedValues;
   }
 
-  getConfigSelections(configId: string | undefined): any {
+  getConfigSelections(configId: string | undefined) {
     const config = this.getById(configId);
-    return config?.selections;
+    return config?.selections || {};
   }
 
   getConfigEvaluatedValues(configId: string | undefined): any {

--- a/client/src/data/project.ts
+++ b/client/src/data/project.ts
@@ -1,7 +1,7 @@
 import { v4 as uuid } from "uuid";
 import { toJS } from "mobx";
 import RootStore from ".";
-import { ConfigValues } from "../utils/modifier-helpers";
+import { ConfigValues } from "./types";
 
 export interface ProjectDetailInterface {
   name: string;

--- a/client/src/data/types.ts
+++ b/client/src/data/types.ts
@@ -1,5 +1,9 @@
+export interface Selection {
+  value: string;
+}
+
 export interface ConfigValues {
-  [key: string]: string; // TODO: make payload shape
+  [key: string]: Selection; // TODO: make payload shape
 }
 
 export interface ConfigInterface {

--- a/client/src/interpreter/display-option.ts
+++ b/client/src/interpreter/display-option.ts
@@ -1,6 +1,11 @@
 ///////////////// Context Mapper: Maps a ConfigContext to a configuration page DisplayList
 
-import { OptionInterface } from "../../src/data/types";
+import {
+  ConfigValues,
+  OptionInterface,
+  TemplateInterface,
+} from "../../src/data/types";
+import { ConfigInterface } from "../data/config";
 
 import {
   ConfigContext,
@@ -208,4 +213,31 @@ export function mapToDisplayOptions(context: ConfigContext) {
   // and keep running until that number doesn't change
   _formatDisplayItem(rootInstance, "", context);
   return _formatDisplayItem(rootInstance, "", context);
+}
+
+/**
+ * Method to santize input when creating a context
+ */
+export function createConfigContext(
+  template: TemplateInterface,
+  config: ConfigInterface,
+  options: { [key: string]: OptionInterface },
+  selections: ConfigValues = {},
+) {
+  const sanitizedSelections = Object.entries(selections).reduce(
+    (acc, [key, selection]) => {
+      if (
+        selection !== null &&
+        typeof selection === "object" &&
+        "value" in selection
+      ) {
+        acc[key] = selection;
+      } else {
+        console.warn(`Unable to process selection`, selection, key);
+      }
+      return acc;
+    },
+    {} as ConfigValues,
+  );
+  return new ConfigContext(template, config, options, sanitizedSelections);
 }

--- a/client/src/interpreter/interpreter.ts
+++ b/client/src/interpreter/interpreter.ts
@@ -1,12 +1,9 @@
 import { ConfigInterface } from "../../src/data/config";
 import { TemplateInterface, OptionInterface } from "../../src/data/types";
 import { removeEmpty } from "../../src/utils/utils";
+import { ConfigValues } from "../../src/data/types";
 
 export type Literal = boolean | string | number;
-
-export interface ConfigValues {
-  [key: string]: string;
-}
 
 export type Expression = {
   operator: string;
@@ -150,7 +147,8 @@ const _instancePathToOption = (
     // check if there is a selected path that specifies that option at
     // this instance path
     if (context.config?.selections) {
-      Object.entries(context.selections).map(([key, value]) => {
+      Object.entries(context.selections).map(([key, selection]) => {
+        const { value } = selection;
         const [, instancePath] = key.split("-");
         if (instancePath === curInstancePathList.join(".")) {
           option = context.options[value];
@@ -578,7 +576,7 @@ const getReplaceableType = (
   const selectionType = selections ? selections[selectionPath] : null;
 
   if (selectionType) {
-    return selectionType;
+    return selectionType.value;
   }
 
   // Check if there is a modifier for this option, if so use it:
@@ -640,7 +638,8 @@ const buildModsHelper = (
         option.modelicaPath,
         newBase,
       );
-      redeclaredType = selections[selectionPath];
+      const selection = selections[selectionPath];
+      redeclaredType = selection.value || "";
     }
 
     if (option.choiceModifiers && redeclaredType) {
@@ -849,7 +848,7 @@ export class ConfigContext {
     // check selections
     if (this.selections && selectionPath in this.selections) {
       this.addToCache(path, optionPath, this.selections[selectionPath]);
-      return this.selections[selectionPath];
+      return this.selections[selectionPath].value;
     }
 
     // Check if a value is on a modifier

--- a/client/src/interpreter/interpreter.ts
+++ b/client/src/interpreter/interpreter.ts
@@ -847,7 +847,7 @@ export class ConfigContext {
     const selectionPath = constructSelectionPath(optionPath, instancePath);
     // check selections
     if (this.selections && selectionPath in this.selections) {
-      this.addToCache(path, optionPath, this.selections[selectionPath]);
+      this.addToCache(path, optionPath, this.selections[selectionPath].value);
       return this.selections[selectionPath].value;
     }
 

--- a/client/tests/interpreter/display-mapping.test.ts
+++ b/client/tests/interpreter/display-mapping.test.ts
@@ -29,13 +29,13 @@ describe("Display Option and Display Group Generation", () => {
     const displayOption = _formatDisplayOption(
       optionInstance as OptionInstance,
       parent?.option.modelicaPath as string,
-      context
+      context,
     );
 
     expect(displayOption).toBeDefined();
     expect(displayOption.selectionType).toEqual("Boolean");
     expect(displayOption.modelicaPath).toEqual(
-      optionInstance?.option?.modelicaPath
+      optionInstance?.option?.modelicaPath,
     );
     expect(displayOption.value).toEqual(false.toString());
   });
@@ -48,12 +48,12 @@ describe("Display Option and Display Group Generation", () => {
     const displayOption = _formatDisplayOption(
       optionInstance as OptionInstance,
       parentInstance?.option.modelicaPath as string,
-      context
+      context,
     );
 
     expect(displayOption.name).toEqual(optionInstance?.option.name);
     expect(displayOption.value).toEqual(
-      "Buildings.Templates.AirHandlersFans.Components.OutdoorSection.SingleDamper"
+      "Buildings.Templates.AirHandlersFans.Components.OutdoorSection.SingleDamper",
     );
 
     const expectedChoicePaths = {
@@ -66,7 +66,7 @@ describe("Display Option and Display Group Generation", () => {
     };
 
     displayOption.choices?.map((c) =>
-      expect(c.modelicaPath in expectedChoicePaths).toBeTruthy()
+      expect(c.modelicaPath in expectedChoicePaths).toBeTruthy(),
     );
   });
 
@@ -74,16 +74,16 @@ describe("Display Option and Display Group Generation", () => {
     const { context } = createTemplateContext(TestTemplate.MultiZoneTemplate);
 
     const enumInstance = context.getOptionInstance(
-      "secOutRel.secOut.typ"
+      "secOutRel.secOut.typ",
     ) as OptionInstance;
     expect(enumInstance?.value).toEqual(
-      "Buildings.Controls.OBC.ASHRAE.G36.Types.OutdoorAirSection.SingleDamper"
+      "Buildings.Controls.OBC.ASHRAE.G36.Types.OutdoorAirSection.SingleDamper",
     );
     const parentInstance = context.getOptionInstance("secOutRel.secOut");
     const displayItems = _formatDisplayItem(
       enumInstance as OptionInstance,
       parentInstance?.option.modelicaPath as string,
-      context
+      context,
     );
 
     expect(displayItems.length).toEqual(0);
@@ -93,7 +93,7 @@ describe("Display Option and Display Group Generation", () => {
     const updatedDisplayItems = _formatDisplayItem(
       enumInstance as OptionInstance,
       parentInstance?.option.modelicaPath as string,
-      context
+      context,
     );
 
     expect(updatedDisplayItems.length).toEqual(1);
@@ -102,7 +102,7 @@ describe("Display Option and Display Group Generation", () => {
   it("Generates a display group", () => {
     const { context } = createTemplateContext(
       TestTemplate.MultiZoneTemplate,
-      createSelections()
+      createSelections(),
     );
 
     // get secOutRel type
@@ -113,7 +113,7 @@ describe("Display Option and Display Group Generation", () => {
     const displayGroup = _formatDisplayGroup(
       secOutRelTypeOption,
       secOutRel as OptionInstance,
-      context
+      context,
     );
 
     const items = displayGroup?.items as (
@@ -128,7 +128,7 @@ describe("Display Option and Display Group Generation", () => {
   it("Generates a display group and display options for Multizone Template", () => {
     const { context } = createTemplateContext(
       TestTemplate.MultiZoneTemplate,
-      {}
+      {},
     );
 
     const displayOptions = mapToDisplayOptions(context);
@@ -139,7 +139,7 @@ describe("Display Option and Display Group Generation", () => {
   it("Hides params with outer designation", () => {
     const { context } = createTemplateContext(
       TestTemplate.MultiZoneTemplate,
-      createSelections()
+      createSelections(),
     );
 
     const coiCoo = context.getOptionInstance("ctl.coiCoo") as OptionInstance;
@@ -152,7 +152,7 @@ describe("Display Option and Display Group Generation", () => {
   it("Generates a display group and display options for VAVBox Cooling Only Template", () => {
     const { context, template } = createTemplateContext(
       TestTemplate.ZoneTemplate,
-      createSelections()
+      createSelections(),
     );
     const coiHea = context.getOptionInstance("coiHea") as OptionInstance;
     expect(coiHea.display).toBeFalsy();
@@ -161,7 +161,7 @@ describe("Display Option and Display Group Generation", () => {
     const ctlDisplayOptions = _formatDisplayItem(
       ctl,
       template.modelicaPath,
-      context
+      context,
     );
 
     expect(ctlDisplayOptions.length).toBeGreaterThan(0);
@@ -175,7 +175,7 @@ describe("Display Enable is set as expected", () => {
   it("Sets enable correctly on parameter with expression", () => {
     const { context } = createTemplateContext(
       TestTemplate.MultiZoneTemplate,
-      createSelections()
+      createSelections(),
     );
 
     const optionInstance = context.getOptionInstance("fanSupBlo");
@@ -184,12 +184,12 @@ describe("Display Enable is set as expected", () => {
     const configName = "VAVMultiZone Config with fanSupDra selection";
     const selections = {
       ["Buildings.Templates.AirHandlersFans.VAVMultiZone.fanSupDra-fanSupDra"]:
-        "Buildings.Templates.Components.Fans.None",
+        { value: "Buildings.Templates.Components.Fans.None" },
     };
 
     const { context: newContext } = createTemplateContext(
       TestTemplate.MultiZoneTemplate,
-      createSelections(selections)
+      createSelections(selections),
     );
 
     const updatedOptionInstance = newContext.getOptionInstance("fanSupBlo");
@@ -199,12 +199,15 @@ describe("Display Enable is set as expected", () => {
   it("Sets ctl.have_CO2Sen param to true", () => {
     const selections = {
       "Buildings.Templates.AirHandlersFans.Components.OutdoorReliefReturnSection.MixedAirWithDamper.secOut-secOutRel.secOut":
-        "Buildings.Templates.AirHandlersFans.Components.OutdoorSection.DedicatedDampersPressure",
+        {
+          value:
+            "Buildings.Templates.AirHandlersFans.Components.OutdoorSection.DedicatedDampersPressure",
+        },
     };
 
     const { context } = createTemplateContext(
       TestTemplate.MultiZoneTemplate,
-      createSelections(selections)
+      createSelections(selections),
     );
 
     const optionInstance = context.getOptionInstance("ctl.have_CO2Sen");
@@ -214,11 +217,11 @@ describe("Display Enable is set as expected", () => {
   it("ctl.have_winSen returns an enabled control", () => {
     const { context } = createTemplateContext(
       TestTemplate.ZoneTemplate,
-      createSelections()
+      createSelections(),
     );
 
     const haveWinSen = context.getOptionInstance(
-      "ctl.have_winSen"
+      "ctl.have_winSen",
     ) as OptionInstance;
     expect(haveWinSen.display).toBeTruthy();
   });

--- a/client/tests/interpreter/modifiers.test.ts
+++ b/client/tests/interpreter/modifiers.test.ts
@@ -60,8 +60,9 @@ describe("Modifiers", () => {
     const { path } = getTestTemplateData(TestTemplate.MultiZoneTemplate);
     const mzOption = allOptions[path];
     const selections = {
-      "Buildings.Templates.AirHandlersFans.VAVMultiZone.coiCoo-coiCoo":
-        "Buildings.Templates.Components.Coils.WaterBasedCooling",
+      "Buildings.Templates.AirHandlersFans.VAVMultiZone.coiCoo-coiCoo": {
+        value: "Buildings.Templates.Components.Coils.WaterBasedCooling",
+      },
     };
     const mods = buildMods(mzOption, selections, allOptions);
     const coiCooPath = "coiCoo.typVal";

--- a/client/tests/interpreter/parameter-debugging.test.ts
+++ b/client/tests/interpreter/parameter-debugging.test.ts
@@ -25,7 +25,7 @@ describe("Specific parameter debugging", () => {
     const optionInstance = context.getOptionInstance(instancePath);
     const selectionPath = constructSelectionPath(
       optionInstance?.option.modelicaPath as string,
-      instancePath
+      instancePath,
     );
     expect(selectionPath in evaluatedValues).toBeTruthy();
   });
@@ -33,7 +33,7 @@ describe("Specific parameter debugging", () => {
   it("Assigns null to secOutRel.secOut.damOut", () => {
     const { context } = createTemplateContext(
       TestTemplate.MultiZoneTemplate,
-      {}
+      {},
     );
 
     const path = "secOutRel.secOut.damOut";
@@ -45,7 +45,7 @@ describe("Specific parameter debugging", () => {
     const evaluatedValues = context.getEvaluatedValues();
     const selectionPath = constructSelectionPath(
       optionInstance?.option.modelicaPath as string,
-      path
+      path,
     );
     expect(path in evaluatedValues).toBeFalsy();
   });
@@ -68,13 +68,14 @@ describe("Specific parameter debugging", () => {
 
   it("coiCoo.typVal should NOT show for any selection of coiCoo", () => {
     const selections = {
-      "Buildings.Templates.AirHandlersFans.VAVMultiZone.coiCoo-coiCoo":
-        "Buildings.Templates.Components.Coils.WaterBasedCooling",
+      "Buildings.Templates.AirHandlersFans.VAVMultiZone.coiCoo-coiCoo": {
+        value: "Buildings.Templates.Components.Coils.WaterBasedCooling",
+      },
     };
 
     const { context: contextWithSelection } = createTemplateContext(
       TestTemplate.MultiZoneTemplate,
-      createSelections(selections)
+      createSelections(selections),
     );
 
     const { context } = createTemplateContext(TestTemplate.MultiZoneTemplate);
@@ -91,7 +92,7 @@ describe("Specific parameter debugging", () => {
       (o) =>
         "groupName" in o &&
         o.groupName ===
-          "Buildings.Templates.AirHandlersFans.VAVMultiZone.coiCoo.__group"
+          "Buildings.Templates.AirHandlersFans.VAVMultiZone.coiCoo.__group",
     ) as FlatConfigOptionGroup;
 
     expect(coiCooDisplayOption).toBeUndefined();
@@ -110,7 +111,7 @@ describe("ctl.have_CO2Sen enable expression", () => {
 
     const ctlTypeValue = context.getValue("typ", "ctl");
     expect(ctlTypeValue).toEqual(
-      "Buildings.Templates.AirHandlersFans.Types.Controller.G36VAVMultiZone"
+      "Buildings.Templates.AirHandlersFans.Types.Controller.G36VAVMultiZone",
     );
 
     const firstOperand = {
@@ -131,11 +132,11 @@ describe("ctl.have_CO2Sen enable expression", () => {
 
     const selections = {
       "Buildings.Templates.AirHandlersFans.Components.OutdoorReliefReturnSection.MixedAirWithDamper.secOut-secOutRel.secOut":
-        secOutValue,
+        { value: secOutValue },
     };
     const { context: newContext } = createTemplateContext(
       TestTemplate.MultiZoneTemplate,
-      createSelections(selections)
+      createSelections(selections),
     );
 
     const secOutTyp = newContext.getValue("secOut.typ", "secOutRel");
@@ -144,14 +145,14 @@ describe("ctl.have_CO2Sen enable expression", () => {
     // ctl.typSecOut -> secOutRel.typSecOut -> secOutRel.secOut.typ -> <secOut selection>.typ
     const typSecOut = newContext.getValue("typSecOut", "ctl"); // secOutRel.typSecOut -> secOut.typ
     expect(typSecOut).toEqual(
-      "Buildings.Controls.OBC.ASHRAE.G36.Types.OutdoorAirSection.DedicatedDampersAirflow"
+      "Buildings.Controls.OBC.ASHRAE.G36.Types.OutdoorAirSection.DedicatedDampersAirflow",
     );
   });
 
   it("Second operand", () => {
     const { context } = createTemplateContext(
       TestTemplate.MultiZoneTemplate,
-      createSelections()
+      createSelections(),
     );
 
     const secondOperand = {
@@ -164,7 +165,7 @@ describe("ctl.have_CO2Sen enable expression", () => {
     let secOutRelTypSecOut = context.getValue("secOutRel.typSecOut", "ctl");
     let typSecOut = context.getValue("typSecOut", "ctl"); // ctl.typSecOut = secOutRel.typSecout
     expect(typSecOut).toEqual(
-      "Buildings.Controls.OBC.ASHRAE.G36.Types.OutdoorAirSection.SingleDamper"
+      "Buildings.Controls.OBC.ASHRAE.G36.Types.OutdoorAirSection.SingleDamper",
     );
 
     let secondEvaluation = evaluate(secondOperand, context, "ctl");
@@ -173,18 +174,21 @@ describe("ctl.have_CO2Sen enable expression", () => {
     // make a context after selection for DedicatedDampersPressure for secOut
     const selections = {
       "Buildings.Templates.AirHandlersFans.Components.OutdoorReliefReturnSection.MixedAirWithDamper.secOut-secOutRel.secOut":
-        "Buildings.Templates.AirHandlersFans.Components.OutdoorSection.DedicatedDampersAirflow",
+        {
+          value:
+            "Buildings.Templates.AirHandlersFans.Components.OutdoorSection.DedicatedDampersAirflow",
+        },
     };
 
     const { context: newContext } = createTemplateContext(
       TestTemplate.MultiZoneTemplate,
-      createSelections(selections)
+      createSelections(selections),
     );
 
     secOutRelTypSecOut = newContext.getValue("secOutRel.typSecOut", "ctl");
     typSecOut = newContext.getValue("typSecOut", "ctl"); // ctl.typSecOut = secOutRel.typSecout
     expect(typSecOut).toEqual(
-      "Buildings.Controls.OBC.ASHRAE.G36.Types.OutdoorAirSection.DedicatedDampersAirflow"
+      "Buildings.Controls.OBC.ASHRAE.G36.Types.OutdoorAirSection.DedicatedDampersAirflow",
     );
 
     secondEvaluation = evaluate(secondOperand, newContext, "ctl");
@@ -194,7 +198,7 @@ describe("ctl.have_CO2Sen enable expression", () => {
   it("Third Operand - includes a datAll param", () => {
     const { context } = createTemplateContext(
       TestTemplate.MultiZoneTemplate,
-      createSelections()
+      createSelections(),
     );
 
     const stdVenValue =
@@ -210,7 +214,7 @@ describe("ctl.have_CO2Sen enable expression", () => {
 
     const stdVen = context.getValue("ctl.stdVen");
     expect(stdVen).toEqual(
-      "Buildings.Controls.OBC.ASHRAE.G36.Types.VentilationStandard.California_Title_24"
+      "Buildings.Controls.OBC.ASHRAE.G36.Types.VentilationStandard.California_Title_24",
     );
 
     const thirdEvaluation = evaluate(thirdOperand, context);
@@ -222,20 +226,20 @@ describe("Scope tests", () => {
   it("Gets value for ctl.typSecOut", () => {
     const { context } = createTemplateContext(
       TestTemplate.MultiZoneTemplate,
-      createSelections()
+      createSelections(),
     );
 
     // falls back to original
     const typSecOut = context.getValue("ctl.typSecOut"); // ctl.typSecOut = secOutRel.typSecOut
     expect(typSecOut).toEqual(
-      "Buildings.Controls.OBC.ASHRAE.G36.Types.OutdoorAirSection.SingleDamper"
+      "Buildings.Controls.OBC.ASHRAE.G36.Types.OutdoorAirSection.SingleDamper",
     );
   });
 
   it("Evaluates the expression at mod secOutRel.secOut.dat", () => {
     const { context } = createTemplateContext(
       TestTemplate.MultiZoneTemplate,
-      createSelections()
+      createSelections(),
     );
     const path = "secOutRel.secOut.dat"; // secOut.dat = dat
     const val = evaluate(context.mods[path]?.expression, context, "secOutRel");
@@ -245,7 +249,7 @@ describe("Scope tests", () => {
   it("Able to resolve secOutRel.secOut.dat without going into an infinite loop due to bad scope", () => {
     const { context } = createTemplateContext(
       TestTemplate.MultiZoneTemplate,
-      createSelections()
+      createSelections(),
     );
     const path = "secOutRel.secOut.dat";
     const expectedVal =
@@ -259,7 +263,7 @@ describe("Scope tests", () => {
     // test modifier value
     // modifier points to the correct parameter definition (secOutRel.dat location)
     expect(context.mods["secOutRel.secOut.dat"].expression.operands[0]).toEqual(
-      "Buildings.Templates.AirHandlersFans.Components.Interfaces.PartialOutdoorReliefReturnSection.dat"
+      "Buildings.Templates.AirHandlersFans.Components.Interfaces.PartialOutdoorReliefReturnSection.dat",
     );
 
     // scope is wrong when we attempt to get value

--- a/client/tests/interpreter/resolve-to-value.test.ts
+++ b/client/tests/interpreter/resolve-to-value.test.ts
@@ -15,7 +15,7 @@ describe("resolveToValue tests using context and evaluation", () => {
     const instancePath = "secOutRel.secRel.fanRet";
     const selections = {
       "Buildings.Templates.AirHandlersFans.Components.ReliefReturnSection.ReturnFan.fanRet-secOutRel.secRel.fanRet":
-        "Buildings.Templates.Components.Fans.ArrayVariable",
+        { value: "Buildings.Templates.Components.Fans.ArrayVariable" },
     };
     const { context } = createTemplateContext(
       TestTemplate.MultiZoneTemplate,
@@ -52,7 +52,7 @@ describe("Testing context getValue", () => {
     const configName = "VAVMultiZone Config with selections";
     const selections = {
       ["Buildings.Templates.AirHandlersFans.VAVMultiZone.fanSupBlo-fanSupBlo"]:
-        "Buildings.Templates.Components.Fans.SingleVariable",
+        { value: "Buildings.Templates.Components.Fans.SingleVariable" },
     };
 
     const { context } = createTemplateContext(

--- a/client/tests/interpreter/selection.test.ts
+++ b/client/tests/interpreter/selection.test.ts
@@ -3,10 +3,12 @@ import { createTemplateContext, createSelections, TestTemplate } from "./utils";
 describe("Multiple Package Selections", () => {
   it("Should allow selections from two different top-level packages (libraries)", () => {
     const firstTemplateNode = "TestPackage.Template.TestTemplate.typ";
-    const firstTemplateNodeSelection = "TestPackage.Types.IceCream.Vanilla";
+    const firstTemplateNodeSelection = {
+      value: "TestPackage.Types.IceCream.Vanilla",
+    };
     const secondTemplateNode =
       "SecondTestPackage.Templates.Plants.Chiller.testParam";
-    const secondTemplateNodeSelection = "true";
+    const secondTemplateNodeSelection = { value: "true" };
 
     const { store, config: testTemplateConfig } = createTemplateContext(
       TestTemplate.TestTemplate,
@@ -37,9 +39,12 @@ describe("Valid selection", () => {
     // you should NOT be able to select secOutRel.secRel.fanRel if a ReliefDamper is specified for secOutRel.secRel
     const selections = {
       "Buildings.Templates.AirHandlersFans.Components.OutdoorReliefReturnSection.MixedAirWithDamper.secRel-secOutRel.secRel":
-        "Buildings.Templates.AirHandlersFans.Components.ReliefReturnSection.ReliefDamper",
+        {
+          value:
+            "Buildings.Templates.AirHandlersFans.Components.ReliefReturnSection.ReliefDamper",
+        },
       "Buildings.Templates.AirHandlersFans.Components.ReliefReturnSection.ReliefFan.fanRel-secOutRel.secRel.fanRel":
-        "Buildings.Templates.Components.Fans.ArrayVariable",
+        { value: "Buildings.Templates.Components.Fans.ArrayVariable" },
     };
 
     const { context } = createTemplateContext(
@@ -58,9 +63,12 @@ describe("Valid selection", () => {
     // you SHOULD be able to select secOutRel.secRel.fanRel if a ReliefDamper is specified for secOutRel.secRel
     const selections = {
       "Buildings.Templates.AirHandlersFans.Components.OutdoorReliefReturnSection.MixedAirWithDamper.secRel-secOutRel.secRel":
-        "Buildings.Templates.AirHandlersFans.Components.ReliefReturnSection.ReliefFan",
+        {
+          value:
+            "Buildings.Templates.AirHandlersFans.Components.ReliefReturnSection.ReliefFan",
+        },
       "Buildings.Templates.AirHandlersFans.Components.ReliefReturnSection.ReliefFan.fanRel-secOutRel.secRel.fanRel":
-        "Buildings.Templates.Components.Fans.ArrayVariable",
+        { value: "Buildings.Templates.Components.Fans.ArrayVariable" },
     };
 
     const { context } = createTemplateContext(
@@ -77,8 +85,10 @@ describe("Valid selection", () => {
 
   it("Handles AllSystem paths", () => {
     const selections = {
-      "Buildings.Templates.Data.AllSystems.ashCliZon":
-        "Buildings.Controls.OBC.ASHRAE.G36.Types.ASHRAEClimateZone.Zone_1A",
+      "Buildings.Templates.Data.AllSystems.ashCliZon": {
+        value:
+          "Buildings.Controls.OBC.ASHRAE.G36.Types.ASHRAEClimateZone.Zone_1A",
+      },
     };
 
     const { context } = createTemplateContext(

--- a/client/tests/interpreter/utils.ts
+++ b/client/tests/interpreter/utils.ts
@@ -12,12 +12,16 @@ import { OperatorType, ConfigContext } from "../../src/interpreter/interpreter";
 
 // initialize global test dependencies
 const projectSelections = {
-  "Buildings.Templates.Data.AllSystems.stdEne":
-    "Buildings.Controls.OBC.ASHRAE.G36.Types.EnergyStandard.ASHRAE90_1",
-  "Buildings.Templates.Data.AllSystems.stdVen":
-    "Buildings.Controls.OBC.ASHRAE.G36.Types.VentilationStandard.California_Title_24",
-  "Buildings.Templates.Data.AllSystems.ashCliZon":
-    "Buildings.Controls.OBC.ASHRAE.G36.Types.ASHRAEClimateZone.Zone_1B",
+  "Buildings.Templates.Data.AllSystems.stdEne": {
+    value: "Buildings.Controls.OBC.ASHRAE.G36.Types.EnergyStandard.ASHRAE90_1",
+  },
+  "Buildings.Templates.Data.AllSystems.stdVen": {
+    value:
+      "Buildings.Controls.OBC.ASHRAE.G36.Types.VentilationStandard.California_Title_24",
+  },
+  "Buildings.Templates.Data.AllSystems.ashCliZon": {
+    value: "Buildings.Controls.OBC.ASHRAE.G36.Types.ASHRAEClimateZone.Zone_1B",
+  },
 };
 
 const mzTemplatePath = "Buildings.Templates.AirHandlersFans.VAVMultiZone";
@@ -42,7 +46,7 @@ export const createSelections = (selections: ConfigValues = {}) => {
 export const addNewConfig = (
   configName: string,
   template: TemplateInterface,
-  selections: { [key: string]: string },
+  selections: ConfigValues,
   store: RootStore,
 ) => {
   store.configStore.add({
@@ -90,9 +94,7 @@ export const createStore = (testStore: TestStore) => {
  */
 export const createTemplateContext = (
   templatePath: TestTemplate,
-  selections: {
-    [key: string]: string;
-  } = {},
+  selections: ConfigValues = {},
   options?: { configName?: string; store: RootStore },
 ) => {
   const {


### PR DESCRIPTION
### Description
Updates the client so that a selection has the shape `{[key: string]: { value: any }}` instead of `{[key: string]: any}`

### Related Issue(s)
#453 

### Testing
- Run client tests: `cd client && npm run test`
- Use the client, make and save selections for a configuration, and check local storage and what is stored for a config. The new shape is now saved into local storage as well