### PR TITLE
Nested SystemTypes: Add 'parent' to SystemType, update SystemType discovery, add tests

### DIFF
--- a/server/tests/integration/parser/template.test.ts
+++ b/server/tests/integration/parser/template.test.ts
@@ -11,18 +11,40 @@ const TEMPLATE_PATH = "TestPackage.Template.TestTemplate";
 const NESTED_TEMPLATE_PATH =
   "TestPackage.NestedTemplate.Subcategory.SecondTemplate";
 
+describe("SystemType extraction", () => {
+    beforeAll(() => {
+    initializeTestModelicaJson();
+    loadPackage('TestPackage');
+  });
+
+  it("Extracts three SystemTypes including subcategories", () => {
+    const systemTypes = [...getSystemTypes()];
+    expect(systemTypes.length).toBe(3);
+  });
+
+  it("Sets the parent value as expected", () => {
+    const systemTypes = [...getSystemTypes()];
+    const noParent = "";
+    const nestedCategoryPath = "TestPackage.NestedTemplate";
+    const subCategory = systemTypes.find(s => s.modelicaPath === "TestPackage.NestedTemplate.Subcategory");
+    const nestedCategory = systemTypes.find(s => s.modelicaPath === nestedCategoryPath);
+    const templateCategory = systemTypes.find(s => s.modelicaPath === "TestPackage.Template");
+
+    expect(subCategory?.parent).toEqual(nestedCategoryPath);
+    expect(nestedCategory?.parent).toEqual(noParent);
+    expect(templateCategory?.parent).toEqual(noParent);
+  });
+});
+
 describe("Template wrapper class functionality", () => {
   beforeAll(() => {
     initializeTestModelicaJson();
     loadPackage('TestPackage');
   });
 
-  it("Extracts two templates and three Template types to be in stores", () => {
+  it("Extracts two templates", () => {
     const templates = [...getTemplates()];
     expect(templates.length).toBe(2);
-
-    const systemTypes = [...getSystemTypes()];
-    expect(systemTypes.length).toBe(2);
   });
 
   it("Templates have expected SystemTypes", () => {


### PR DESCRIPTION
### Description
Server updates to support nested SystemTypes. 

- Adds the `parent` attribute to SystemType
- Updates SystemType extraction process to populate the `parent` field
- Adds tests for SystemType extraction

### Related Issue(s)
#455 

### Testing
Tests have been updated on the server
