### PR TITLE
Include component name in path for nested modifications

### DIFF
--- a/server/src/parser/modification.ts
+++ b/server/src/parser/modification.ts
@@ -248,7 +248,9 @@ function unpackModblock(props: ModificationProps) {
         ) as mj.ClassMod;
         // Additional modifiers can be attached to choice
         if (classModification) {
-          mods = getModificationList(classModification, basePath, value);
+          // Include component name in path for nested modifications
+          const nestedBasePath = [basePath, name].filter((s) => s).join(".");
+          mods = getModificationList(classModification, nestedBasePath, value);
           // TODO: getModificationList should handle redeclares but it is not
           // correctly unpacking nested modifiers - this is a bug
           // kludge: remove nested modifiers
@@ -264,7 +266,9 @@ function unpackModblock(props: ModificationProps) {
         const modType = modElement?.type;
         typePath = modType ? modType : baseType;
       }
-      mods = getModificationList(mod as mj.ClassMod, basePath, typePath); //mod.class_modification
+      // Include component name in path for nested modifications
+      const nestedBasePath = [basePath, name].filter((s) => s).join(".");
+      mods = getModificationList(mod as mj.ClassMod, nestedBasePath, typePath);
     }
   }
 


### PR DESCRIPTION
### Related Issue(s)

This addresses #480.

### Testing

The parsed template file `templates.json` now contains adequate modifier keys:
```jsonc
    {
      "modelicaPath": "Buildings.Templates.AirHandlersFans.VAVMultiZone",
      "type": "Buildings.Templates.AirHandlersFans.VAVMultiZone",
      "name": "Multiple-zone VAV",
      "value": "Buildings.Templates.AirHandlersFans.VAVMultiZone",
      "visible": false,
      "modifiers": {
        "Buildings.Templates.AirHandlersFans.VAVMultiZone.nZon.min": { // Correct for modification 'nZon(min=...)'
```
where it used to be
```jsonc
    {
      "modelicaPath": "Buildings.Templates.AirHandlersFans.VAVMultiZone",
      "type": "Buildings.Templates.AirHandlersFans.VAVMultiZone",
      "name": "Multiple-zone VAV",
      "value": "Buildings.Templates.AirHandlersFans.VAVMultiZone",
      "visible": false,
      "modifiers": {
        "Buildings.Templates.AirHandlersFans.VAVMultiZone.min": { // Incorrect for modification 'nZon(min=...)'
```

End-to-end tests have been performed by creating the SOO document with the following system options.

AHU
- Separate dampers w/ dp
- Modulating relief w/o fan
- No heating coil
- Freeze stat hardwired to both

Cooling-only box
- 3 sensors = true

The feature branch produces the same document as the main branch.