### PR TITLE
Parse element-level modifiers of replaceable elements

### DIFF
--- a/client/src/data/templates.json
+++ b/client/src/data/templates.json
@@ -110,7 +110,117 @@
       "group": "Configuration",
       "tab": "",
       "visible": true,
-      "modifiers": {},
+      "modifiers": {
+        "Buildings.Templates.AirHandlersFans.VAVMultiZone.secOutRel.MediumAir": {
+          "final": true,
+          "redeclare": "Buildings.Templates.AirHandlersFans.Interfaces.PartialAirHandler.MediumAir"
+        },
+        "Buildings.Templates.AirHandlersFans.VAVMultiZone.secOutRel.typCtlFanRet": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "ctl.typCtlFanRet"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.AirHandlersFans.VAVMultiZone.secOutRel.typCtlEco": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "ctl.typCtlEco"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.AirHandlersFans.VAVMultiZone.secOutRel.energyDynamics": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "energyDynamics"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.AirHandlersFans.VAVMultiZone.secOutRel.allowFlowReversal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "allowFlowReversalAir"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.AirHandlersFans.VAVMultiZone.secOutRel.dat.mOutMin_flow_nominal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dat.mOutMin_flow_nominal"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.AirHandlersFans.VAVMultiZone.secOutRel.dat.damOut": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dat.damOut"
+            ]
+          },
+          "final": true,
+          "recordBinding": true
+        },
+        "Buildings.Templates.AirHandlersFans.VAVMultiZone.secOutRel.dat.damOutMin": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dat.damOutMin"
+            ]
+          },
+          "final": true,
+          "recordBinding": true
+        },
+        "Buildings.Templates.AirHandlersFans.VAVMultiZone.secOutRel.dat.damRel": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dat.damRel"
+            ]
+          },
+          "final": true,
+          "recordBinding": true
+        },
+        "Buildings.Templates.AirHandlersFans.VAVMultiZone.secOutRel.dat.damRet": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dat.damRet"
+            ]
+          },
+          "final": true,
+          "recordBinding": true
+        },
+        "Buildings.Templates.AirHandlersFans.VAVMultiZone.secOutRel.dat.fanRel": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dat.fanRel"
+            ]
+          },
+          "final": true,
+          "recordBinding": true
+        },
+        "Buildings.Templates.AirHandlersFans.VAVMultiZone.secOutRel.dat.fanRet": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dat.fanRet"
+            ]
+          },
+          "final": true,
+          "recordBinding": true
+        }
+      },
       "enable": false,
       "choiceModifiers": {},
       "replaceable": true,
@@ -5666,7 +5776,26 @@
       "group": "",
       "tab": "",
       "visible": true,
-      "modifiers": {},
+      "modifiers": {
+        "Buildings.Templates.Components.Data.Fan.per.pressure.V_flow": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "{0,1,2}*m_flow_nominal/1.2/max(1,nFan)"
+            ]
+          },
+          "final": false
+        },
+        "Buildings.Templates.Components.Data.Fan.per.pressure.dp": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "{1.5,1,0}*dp_nominal"
+            ]
+          },
+          "final": false
+        }
+      },
       "enable": {
         "operator": "!=",
         "operands": [
@@ -19367,6 +19496,19 @@
             ]
           },
           "final": true
+        },
+        "Buildings.Templates.AirHandlersFans.VAVMultiZone.coiHeaPre.MediumHeaWat": {
+          "final": true,
+          "redeclare": "Buildings.Templates.AirHandlersFans.Interfaces.PartialAirHandler.MediumHeaWat"
+        },
+        "Buildings.Templates.AirHandlersFans.VAVMultiZone.coiHeaPre.typVal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "Buildings.Templates.Components.Types.Valve.TwoWayModulating"
+            ]
+          },
+          "final": true
         }
       },
       "enable": {
@@ -21611,7 +21753,26 @@
       "group": "Configuration",
       "tab": "",
       "visible": true,
-      "modifiers": {},
+      "modifiers": {
+        "Buildings.Templates.Components.Actuators.Valve.flowCharacteristics.y": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "{0,1}"
+            ]
+          },
+          "final": false
+        },
+        "Buildings.Templates.Components.Actuators.Valve.flowCharacteristics.phi": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "{0.0001,1}"
+            ]
+          },
+          "final": false
+        }
+      },
       "enable": {
         "operator": "&&",
         "operands": [
@@ -21741,7 +21902,26 @@
       "group": "Configuration",
       "tab": "",
       "visible": true,
-      "modifiers": {},
+      "modifiers": {
+        "Buildings.Templates.Components.Actuators.Valve.flowCharacteristics1.y": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "{0,1}"
+            ]
+          },
+          "final": false
+        },
+        "Buildings.Templates.Components.Actuators.Valve.flowCharacteristics1.phi": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "{0.0001,1}"
+            ]
+          },
+          "final": false
+        }
+      },
       "enable": {
         "operator": "&&",
         "operands": [
@@ -21788,7 +21968,26 @@
       "group": "Configuration",
       "tab": "",
       "visible": true,
-      "modifiers": {},
+      "modifiers": {
+        "Buildings.Templates.Components.Actuators.Valve.flowCharacteristics3.y": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "{0,1}"
+            ]
+          },
+          "final": false
+        },
+        "Buildings.Templates.Components.Actuators.Valve.flowCharacteristics3.phi": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "{0.0001,1}"
+            ]
+          },
+          "final": false
+        }
+      },
       "enable": {
         "operator": "&&",
         "operands": [
@@ -25185,6 +25384,97 @@
             "operator": "none",
             "operands": [
               "show_T"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.Components.Coils.WaterBasedHeating.hex.configuration": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "Buildings.Fluid.Types.HeatExchangerConfiguration.CounterFlow"
+            ]
+          },
+          "final": false
+        },
+        "Buildings.Templates.Components.Coils.WaterBasedHeating.hex.use_Q_flow_nominal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              true
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.Components.Coils.WaterBasedHeating.hex.Q_flow_nominal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "Q_flow_nominal"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.Components.Coils.WaterBasedHeating.hex.T_a1_nominal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dat.TWatEnt_nominal"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.Components.Coils.WaterBasedHeating.hex.T_a2_nominal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dat.TAirEnt_nominal"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.Components.Coils.WaterBasedHeating.hex.dp1_nominal": {
+          "expression": {
+            "operator": "if_elseif",
+            "operands": [
+              {
+                "operator": "if",
+                "operands": [
+                  {
+                    "operator": "==",
+                    "operands": [
+                      "val.typ",
+                      "Buildings.Templates.Components.Types.Valve.None"
+                    ]
+                  },
+                  {
+                    "operator": "none",
+                    "operands": [
+                      "dpWat_nominal"
+                    ]
+                  }
+                ]
+              },
+              {
+                "operator": "else",
+                "operands": [
+                  {
+                    "operator": "none",
+                    "operands": [
+                      0
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.Components.Coils.WaterBasedHeating.hex.dp2_nominal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dpAir_nominal"
             ]
           },
           "final": true
@@ -28829,6 +29119,19 @@
             ]
           },
           "final": true
+        },
+        "Buildings.Templates.AirHandlersFans.VAVMultiZone.coiCoo.MediumChiWat": {
+          "final": true,
+          "redeclare": "Buildings.Templates.AirHandlersFans.Interfaces.PartialAirHandler.MediumChiWat"
+        },
+        "Buildings.Templates.AirHandlersFans.VAVMultiZone.coiCoo.typVal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "Buildings.Templates.Components.Types.Valve.TwoWayModulating"
+            ]
+          },
+          "final": true
         }
       },
       "enable": true,
@@ -29049,6 +29352,106 @@
             "operator": "none",
             "operands": [
               "show_T"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.Components.Coils.WaterBasedCooling.hex.configuration": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "Buildings.Fluid.Types.HeatExchangerConfiguration.CounterFlow"
+            ]
+          },
+          "final": false
+        },
+        "Buildings.Templates.Components.Coils.WaterBasedCooling.hex.use_Q_flow_nominal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              true
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.Components.Coils.WaterBasedCooling.hex.Q_flow_nominal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "Q_flow_nominal"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.Components.Coils.WaterBasedCooling.hex.T_a1_nominal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dat.TWatEnt_nominal"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.Components.Coils.WaterBasedCooling.hex.T_a2_nominal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dat.TAirEnt_nominal"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.Components.Coils.WaterBasedCooling.hex.w_a2_nominal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dat.wAirEnt_nominal"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.Components.Coils.WaterBasedCooling.hex.dp1_nominal": {
+          "expression": {
+            "operator": "if_elseif",
+            "operands": [
+              {
+                "operator": "if",
+                "operands": [
+                  {
+                    "operator": "==",
+                    "operands": [
+                      "val.typ",
+                      "Buildings.Templates.Components.Types.Valve.None"
+                    ]
+                  },
+                  {
+                    "operator": "none",
+                    "operands": [
+                      "dpWat_nominal"
+                    ]
+                  }
+                ]
+              },
+              {
+                "operator": "else",
+                "operands": [
+                  {
+                    "operator": "none",
+                    "operands": [
+                      0
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.Components.Coils.WaterBasedCooling.hex.dp2_nominal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dpAir_nominal"
             ]
           },
           "final": true
@@ -62123,7 +62526,44 @@
       "group": "",
       "tab": "",
       "visible": true,
-      "modifiers": {},
+      "modifiers": {
+        "Buildings.Templates.AirHandlersFans.Components.Interfaces.PartialController.dat.typ": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "typ"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.AirHandlersFans.Components.Interfaces.PartialController.dat.typFanSup": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "typFanSup"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.AirHandlersFans.Components.Interfaces.PartialController.dat.typFanRel": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "typFanRel"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.AirHandlersFans.Components.Interfaces.PartialController.dat.typFanRet": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "typFanRet"
+            ]
+          },
+          "final": true
+        }
+      },
       "enable": true,
       "choiceModifiers": {},
       "replaceable": true,
@@ -62590,7 +63030,62 @@
       "group": "",
       "tab": "",
       "visible": true,
-      "modifiers": {},
+      "modifiers": {
+        "Buildings.Templates.AirHandlersFans.Interfaces.PartialAirHandler.cfg.typ": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "typ"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.AirHandlersFans.Interfaces.PartialAirHandler.cfg.typFanSup": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "typFanSup"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.AirHandlersFans.Interfaces.PartialAirHandler.cfg.typFanRel": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "typFanRel"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.AirHandlersFans.Interfaces.PartialAirHandler.cfg.typFanRet": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "typFanRet"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.AirHandlersFans.Interfaces.PartialAirHandler.cfg.have_souChiWat": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "have_souChiWat"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.AirHandlersFans.Interfaces.PartialAirHandler.cfg.have_souHeaWat": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "have_souHeaWat"
+            ]
+          },
+          "final": true
+        }
+      },
       "enable": true,
       "choiceModifiers": {},
       "replaceable": true,
@@ -62951,7 +63446,18 @@
       "group": "",
       "tab": "",
       "visible": true,
-      "modifiers": {},
+      "modifiers": {
+        "Buildings.Templates.AirHandlersFans.Interfaces.PartialAirHandler.dat.cfg": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "cfg"
+            ]
+          },
+          "final": false,
+          "recordBinding": true
+        }
+      },
       "enable": true,
       "choiceModifiers": {},
       "replaceable": true,
@@ -63045,7 +63551,44 @@
       "group": "Controls",
       "tab": "",
       "visible": true,
-      "modifiers": {},
+      "modifiers": {
+        "Buildings.Templates.AirHandlersFans.Data.PartialAirHandler.ctl.typFanSup": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "cfg.typFanSup"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.AirHandlersFans.Data.PartialAirHandler.ctl.typFanRel": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "cfg.typFanRel"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.AirHandlersFans.Data.PartialAirHandler.ctl.typFanRet": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "cfg.typFanRet"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.AirHandlersFans.Data.PartialAirHandler.ctl.typ": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "cfg.typCtl"
+            ]
+          },
+          "final": true
+        }
+      },
       "enable": true,
       "choiceModifiers": {},
       "replaceable": true,
@@ -66602,6 +67145,19 @@
             ]
           },
           "final": true
+        },
+        "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.coiHea.MediumHeaWat": {
+          "final": true,
+          "redeclare": "Buildings.Templates.ZoneEquipment.Interfaces.PartialAirTerminal.MediumHeaWat"
+        },
+        "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.coiHea.typVal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "Buildings.Templates.Components.Types.Valve.TwoWayModulating"
+            ]
+          },
+          "final": true
         }
       },
       "enable": true,
@@ -66923,7 +67479,17 @@
       "group": "",
       "tab": "",
       "visible": true,
-      "modifiers": {},
+      "modifiers": {
+        "Buildings.Templates.ZoneEquipment.Components.Interfaces.PartialController.dat.typ": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "typ"
+            ]
+          },
+          "final": true
+        }
+      },
       "enable": true,
       "choiceModifiers": {},
       "replaceable": true,
@@ -67339,7 +67905,35 @@
       "group": "",
       "tab": "",
       "visible": true,
-      "modifiers": {},
+      "modifiers": {
+        "Buildings.Templates.ZoneEquipment.Interfaces.PartialAirTerminal.cfg.typ": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "typ"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.ZoneEquipment.Interfaces.PartialAirTerminal.cfg.have_souChiWat": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "have_souChiWat"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.ZoneEquipment.Interfaces.PartialAirTerminal.cfg.have_souHeaWat": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "have_souHeaWat"
+            ]
+          },
+          "final": true
+        }
+      },
       "enable": true,
       "choiceModifiers": {},
       "replaceable": true,
@@ -67636,7 +68230,17 @@
       "group": "Controls",
       "tab": "",
       "visible": true,
-      "modifiers": {},
+      "modifiers": {
+        "Buildings.Templates.ZoneEquipment.Data.PartialAirTerminal.ctl.typ": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "cfg.typCtl"
+            ]
+          },
+          "final": true
+        }
+      },
       "enable": true,
       "choiceModifiers": {},
       "replaceable": true,

--- a/server/src/parser/parser.ts
+++ b/server/src/parser/parser.ts
@@ -516,16 +516,21 @@ export class ShortClass extends Element {
     this.description = definition.description?.description_string;
     this.replaceable = definition.replaceable;
 
-    if (specifier.value?.class_modification) {
-      this.mods = getModificationList(
-        specifier.value,
-        this.modelicaPath,
-        this.type,
-      );
-    }
+    // Capture element-level mods before initializeReplaceable resets this.mods.
+    // For non-replaceable short classes these are set directly; for replaceable
+    // ones they are merged after constraining-clause mods (element mods win per
+    // Modelica spec §7.3.2).
+    const elementMods: Modification[] = specifier.value?.class_modification
+      ? getModificationList(specifier.value, this.modelicaPath, this.type)
+      : [];
 
     if (this.replaceable) {
       initializeReplaceable(this, definition, basePath);
+      if (elementMods.length) {
+        this.mods = [...(this.mods || []), ...elementMods];
+      }
+    } else {
+      this.mods = elementMods.length ? elementMods : this.mods;
     }
     setUIInfo(this);
   }
@@ -817,6 +822,12 @@ export class Component extends Element implements Replaceable {
     if (this.replaceable) {
       // The following may modify descriptionBlock and this.annotation
       initializeReplaceable(this, definition, basePath);
+      // Merge element-level modifiers AFTER constraining-clause mods so they
+      // take precedence per Modelica spec §7.3.2 (constraining-clause modifiers
+      // apply across redeclarations but are overridden by element modifiers).
+      if (this.mod?.mods?.length) {
+        this.mods = [...(this.mods || []), ...this.mod.mods];
+      }
     }
 
     // Must be called last since it uses this.annotation

--- a/server/tests/integration/parser/modifiers.test.ts
+++ b/server/tests/integration/parser/modifiers.test.ts
@@ -125,6 +125,33 @@ describe("Modifications", () => {
     expect(mod.expression).toBeUndefined();
   });
 
+  /**
+   * Regression test for https://github.com/lbl-srg/ctrl-flow-dev/issues/418
+   * Element-level modifiers on a replaceable must be captured alongside
+   * constraining-clause modifiers.
+   */
+  it("Includes element-level modifiers on replaceable (not just constraining-clause mods)", () => {
+    const path =
+      "TestPackage.Template.TestTemplate.selectable_component_with_element_mods";
+    const constrainingModPath = `${path}.container`; // from constraining clause
+    const elementModPath = `${path}.icecream`; // from element itself
+    const option = tOptions[path];
+    const mods = option.modifiers;
+
+    // Constraining-clause modifier should be present
+    expect(mods[constrainingModPath]).toBeTruthy();
+    expect(
+      evaluateExpression(mods[constrainingModPath].expression),
+    ).toEqual("TestPackage.Types.Container.Cone");
+
+    // Element-level modifier should be present and take precedence over constraining clause modifiers
+    expect(mods[elementModPath]).toBeTruthy();
+    expect(
+      evaluateExpression(mods[elementModPath].expression),
+    ).toEqual("first.icecream");
+    expect(mods[elementModPath].final).toBe(true);
+  });
+
   it("Doesn't have a modifier that matches the option path (the 'default mod')", () => {
     const path = "TestPackage.Template.TestTemplate.typ";
     const option = tOptions[path];

--- a/server/tests/static-data/TestPackage/Template/TestTemplate.mo
+++ b/server/tests/static-data/TestPackage/Template/TestTemplate.mo
@@ -145,6 +145,30 @@ model TestTemplate "Test Template"
     local_var="Modified Value"
   );
 
+  /*
+    Test that element-level modifiers on a replaceable are captured
+    (not just the modifiers from the constraining clause)
+  */
+  inner replaceable
+    TestPackage.Component.SecondComponent
+    selectable_component_with_element_mods(
+      final icecream=first.icecream
+    ) constrainedby TestPackage.Interface.PartialComponent(
+      final container=TestPackage.Types.Container.Cone,
+      icecream=third.icecream
+    )
+    "Replaceable Component with both element and constraining-clause modifiers"
+    annotation (
+      choices(
+        choice(
+          redeclare replaceable TestPackage.Component.SecondComponent selectable_component_with_element_mods
+          "Second Test Component"),
+        choice(
+          redeclare replaceable TestPackage.Component.ThirdComponent selectable_component_with_element_mods
+          "Third Test Component")
+      )
+    );
+
   inner replaceable
     Component.SecondComponent
     selectable_component_with_relative_paths constrainedby


### PR DESCRIPTION
### Description

This addresses #418

### Testing

A regression test has been added in `server/tests/integration/parser/modifiers.test.ts` to check that element-level modifiers are included and take precedence over the constraining clause modifiers.

End-to-end tests have also been performed by creating the SOO document with the following system options.

AHU

- Separate dampers w/ dp
- Modulating relief w/o fan
- No heating coil
- Freeze stat hardwired to both

Cooling-only box

- 3 sensors = true

✅ The staging branch produces the same document as the main branch.

### To Do

Once this PR is merged, the annotation `__ctrlFlow(enable=false)` can be removed in 
https://github.com/lbl-srg/modelica-buildings/blob/master/Buildings/Templates/AirHandlersFans/Components/Interfaces/PartialOutdoorReliefReturnSection.mo#L57C17-L57C41
and
https://github.com/lbl-srg/modelica-buildings/blob/master/Buildings/Templates/AirHandlersFans/Components/Interfaces/PartialOutdoorReliefReturnSection.mo#L65

And the MBL commit after that change can be used at https://github.com/lbl-srg/ctrl-flow-dev/blob/main/server/bin/install-modelica-dependencies.sh#L4
