### PR TITLE
Restrict enum options with declaration-level choices annotation

### DIFF
--- a/server/src/parser/parser.ts
+++ b/server/src/parser/parser.ts
@@ -854,6 +854,19 @@ export class Component extends Element implements Replaceable {
         ? []
         : typeInputs[this.type]?.inputs || [];
 
+    // If a choices annotation is present at the declaration level, restrict
+    // childInputs to the specified choices (e.g. a subset of enum values).
+    const choicesAnnotation = this.annotation.find((m) => m.name === "choices");
+    if (choicesAnnotation && childInputs.length > 0) {
+      const specifiedChoices = choicesAnnotation.mods
+        .filter((c) => c.value)
+        .map((c) => evaluateExpression(c.value) as string)
+        .filter(Boolean);
+      if (specifiedChoices.length > 0) {
+        childInputs = childInputs.filter((c) => specifiedChoices.includes(c));
+      }
+    }
+
     childInputs.filter((typeInputs) => {
       const element = typeStore.get(typeInputs);
       return !element?.deadEnd;

--- a/server/tests/integration/parser/parsed-elements.test.ts
+++ b/server/tests/integration/parser/parsed-elements.test.ts
@@ -194,6 +194,28 @@ describe("Expected elements are extracted", () => {
     });
   });
 
+  it("Declaration-level choices annotation restricts enum options", () => {
+    const file = parser.getFile(testModelicaFile) as parser.File;
+    const template = file.elementList[0] as parser.LongClass;
+    const parentPath = "TestPackage.Template.TestTemplate.typ_limited";
+    const element = template.elementList?.find(
+      (e) => e.modelicaPath === parentPath,
+    ) as parser.Element;
+    const inputs = element.getInputs();
+    const parent = inputs[parentPath];
+
+    expect(parent.inputs?.length).toEqual(2);
+    expect(parent.inputs).toContain(
+      "TestPackage.Types.IceCream.Chocolate",
+    );
+    expect(parent.inputs).toContain(
+      "TestPackage.Types.IceCream.Vanilla",
+    );
+    expect(parent.inputs).not.toContain(
+      "TestPackage.Types.IceCream.Strawberry",
+    );
+  });
+
   it("Extracts expected LongClass inputs", () => {
     const file = parser.getFile(testModelicaFile) as parser.File;
     const longClass = file.elementList[0] as parser.LongClass;

--- a/server/tests/static-data/TestPackage/Template/TestTemplate.mo
+++ b/server/tests/static-data/TestPackage/Template/TestTemplate.mo
@@ -124,6 +124,18 @@ model TestTemplate "Test Template"
       Evaluate=true,
       Dialog(group="Configuration"));
 
+  parameter TestPackage.Types.IceCream typ_limited =
+    TestPackage.Types.IceCream.Chocolate
+    "Test Enum with restricted choices"
+    annotation (
+      Evaluate=true,
+      Dialog(group="Configuration"),
+      choices(
+        choice=TestPackage.Types.IceCream.Chocolate
+        "Chocolate",
+        choice=TestPackage.Types.IceCream.Vanilla
+        "Vanilla"));
+
   // redclare modifier params
   TestPackage.Component.FourthComponent redeclare_param_01(
       redeclare final TestPackage.Component.SecondComponent replaceable_param


### PR DESCRIPTION
### Description

This addresses #552. 

### Testing

A regression test has been added:
```bash
npx jest -t "Declaration-level choices annotation restricts enum options"
```

End-to-end tests have also been performed by creating the SOO document with the following system options.

AHU

- Separate dampers w/ dp
- Modulating relief w/o fan
- No heating coil
- Freeze stat hardwired to both

Cooling-only box

- 3 sensors = true

✅ The feature branch produces the same document as the main branch.