### PR TITLE
Parse public & protected sections

### DIFF
--- a/client/src/data/templates.json
+++ b/client/src/data/templates.json
@@ -21143,6 +21143,276 @@
       "shortExclType": false
     },
     {
+      "modelicaPath": "Buildings.Templates.Components.Interfaces.PartialCoil.datVal",
+      "type": "Buildings.Templates.Components.Data.Valve",
+      "name": "Local record for control valve with lumped flow resistance",
+      "group": "",
+      "tab": "",
+      "visible": false,
+      "enable": true,
+      "modifiers": {
+        "Buildings.Templates.Components.Interfaces.PartialCoil.datVal.typ": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "typVal"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.Components.Interfaces.PartialCoil.datVal.m_flow_nominal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dat.mWat_flow_nominal"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.Components.Interfaces.PartialCoil.datVal.dpValve_nominal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dat.dpValve_nominal"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.Components.Interfaces.PartialCoil.datVal.dpFixed_nominal": {
+          "expression": {
+            "operator": "if_elseif",
+            "operands": [
+              {
+                "operator": "if",
+                "operands": [
+                  {
+                    "operator": "!=",
+                    "operands": [
+                      "typVal",
+                      "Buildings.Templates.Components.Types.Valve.None"
+                    ]
+                  },
+                  {
+                    "operator": "none",
+                    "operands": [
+                      "dat.dpWat_nominal"
+                    ]
+                  }
+                ]
+              },
+              {
+                "operator": "else",
+                "operands": [
+                  {
+                    "operator": "none",
+                    "operands": [
+                      0
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "final": true
+        }
+      },
+      "replaceable": false,
+      "options": [
+        "Buildings.Templates.Components.Data.Valve.typ",
+        "Buildings.Templates.Components.Data.Valve.m_flow_nominal",
+        "Buildings.Templates.Components.Data.Valve.dpValve_nominal",
+        "Buildings.Templates.Components.Data.Valve.dpFixed_nominal",
+        "Buildings.Templates.Components.Data.Valve.dpFixedByp_nominal"
+      ],
+      "definition": false,
+      "shortExclType": false
+    },
+    {
+      "modelicaPath": "Buildings.Templates.Components.Data.Valve.typ",
+      "type": "Buildings.Templates.Components.Types.Valve",
+      "name": "Equipment type",
+      "group": "Configuration",
+      "tab": "",
+      "visible": true,
+      "enable": false,
+      "modifiers": {},
+      "replaceable": false,
+      "options": [],
+      "definition": false,
+      "shortExclType": false
+    },
+    {
+      "modelicaPath": "Buildings.Templates.Components.Data.Valve.m_flow_nominal",
+      "type": "Modelica.Units.SI.MassFlowRate",
+      "name": "Nominal mass flow rate of fully open valve",
+      "group": "Nominal condition",
+      "tab": "",
+      "visible": false,
+      "enable": {
+        "operator": "!=",
+        "operands": [
+          "typ",
+          "Buildings.Templates.Components.Types.Valve.None"
+        ]
+      },
+      "modifiers": {
+        "Buildings.Templates.Components.Data.Valve.m_flow_nominal.min": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              0
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.Components.Data.Valve.m_flow_nominal.start": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              1
+            ]
+          },
+          "final": false
+        }
+      },
+      "replaceable": false,
+      "options": [],
+      "definition": false,
+      "shortExclType": false
+    },
+    {
+      "modelicaPath": "Buildings.Templates.Components.Data.Valve.dpValve_nominal",
+      "type": "Modelica.Units.SI.PressureDifference",
+      "name": "Nominal pressure drop of fully open valve",
+      "group": "Nominal condition",
+      "tab": "",
+      "visible": false,
+      "enable": {
+        "operator": "!=",
+        "operands": [
+          "typ",
+          "Buildings.Templates.Components.Types.Valve.None"
+        ]
+      },
+      "modifiers": {
+        "Buildings.Templates.Components.Data.Valve.dpValve_nominal.min": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              0
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.Components.Data.Valve.dpValve_nominal.displayUnit": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "Pa"
+            ]
+          },
+          "final": false
+        },
+        "Buildings.Templates.Components.Data.Valve.dpValve_nominal.start": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              0
+            ]
+          },
+          "final": false
+        }
+      },
+      "replaceable": false,
+      "options": [],
+      "definition": false,
+      "shortExclType": false
+    },
+    {
+      "modelicaPath": "Buildings.Templates.Components.Data.Valve.dpFixed_nominal",
+      "type": "Modelica.Units.SI.PressureDifference",
+      "value": {
+        "operator": "none",
+        "operands": [
+          0
+        ]
+      },
+      "name": "Nominal pressure drop of pipes and other equipment in flow leg",
+      "group": "Nominal condition",
+      "tab": "",
+      "visible": false,
+      "enable": {
+        "operator": "!=",
+        "operands": [
+          "typ",
+          "Buildings.Templates.Components.Types.Valve.None"
+        ]
+      },
+      "modifiers": {},
+      "replaceable": false,
+      "options": [],
+      "definition": false,
+      "shortExclType": false
+    },
+    {
+      "modelicaPath": "Buildings.Templates.Components.Data.Valve.dpFixedByp_nominal",
+      "type": "Modelica.Units.SI.PressureDifference",
+      "value": {
+        "operator": "none",
+        "operands": [
+          "dpFixed_nominal"
+        ]
+      },
+      "name": "Nominal pressure drop in the bypass line",
+      "group": "Nominal condition",
+      "tab": "",
+      "visible": false,
+      "enable": {
+        "operator": "||",
+        "operands": [
+          {
+            "operator": "==",
+            "operands": [
+              "typ",
+              "Buildings.Templates.Components.Types.Valve.ThreeWayTwoPosition"
+            ]
+          },
+          {
+            "operator": "==",
+            "operands": [
+              "typ",
+              "Buildings.Templates.Components.Types.Valve.ThreeWayModulating"
+            ]
+          }
+        ]
+      },
+      "modifiers": {},
+      "replaceable": false,
+      "options": [],
+      "definition": false,
+      "shortExclType": false
+    },
+    {
+      "modelicaPath": "Buildings.Templates.Components.Data.Valve",
+      "type": "Buildings.Templates.Components.Data.Valve",
+      "name": "Record for valve model",
+      "visible": false,
+      "modifiers": {},
+      "replaceable": false,
+      "options": [
+        "Buildings.Templates.Components.Data.Valve.typ",
+        "Buildings.Templates.Components.Data.Valve.m_flow_nominal",
+        "Buildings.Templates.Components.Data.Valve.dpValve_nominal",
+        "Buildings.Templates.Components.Data.Valve.dpFixed_nominal",
+        "Buildings.Templates.Components.Data.Valve.dpFixedByp_nominal"
+      ],
+      "definition": true,
+      "shortExclType": false,
+      "treeList": [
+        "Buildings.Templates.Components.Data.Valve"
+      ]
+    },
+    {
       "modelicaPath": "Buildings.Templates.Components.Interfaces.PartialCoil",
       "type": "Buildings.Templates.Components.Interfaces.PartialCoil",
       "name": "Interface class for coil",
@@ -21183,7 +21453,8 @@
         "Buildings.Templates.Components.Interfaces.PartialCoil.port_aSou",
         "Buildings.Templates.Components.Interfaces.PartialCoil.port_bSou",
         "Buildings.Templates.Components.Interfaces.PartialCoil.busWea",
-        "Buildings.Templates.Components.Interfaces.PartialCoil.bus"
+        "Buildings.Templates.Components.Interfaces.PartialCoil.bus",
+        "Buildings.Templates.Components.Interfaces.PartialCoil.datVal"
       ],
       "definition": true,
       "shortExclType": false,
@@ -21228,7 +21499,8 @@
         "Buildings.Templates.Components.Interfaces.PartialCoil.port_aSou",
         "Buildings.Templates.Components.Interfaces.PartialCoil.port_bSou",
         "Buildings.Templates.Components.Interfaces.PartialCoil.busWea",
-        "Buildings.Templates.Components.Interfaces.PartialCoil.bus"
+        "Buildings.Templates.Components.Interfaces.PartialCoil.bus",
+        "Buildings.Templates.Components.Interfaces.PartialCoil.datVal"
       ],
       "definition": true,
       "shortExclType": false,
@@ -22070,191 +22342,6 @@
       "options": [],
       "definition": false,
       "shortExclType": false
-    },
-    {
-      "modelicaPath": "Buildings.Templates.Components.Data.Valve.typ",
-      "type": "Buildings.Templates.Components.Types.Valve",
-      "name": "Equipment type",
-      "group": "Configuration",
-      "tab": "",
-      "visible": true,
-      "enable": false,
-      "modifiers": {},
-      "replaceable": false,
-      "options": [],
-      "definition": false,
-      "shortExclType": false
-    },
-    {
-      "modelicaPath": "Buildings.Templates.Components.Data.Valve.m_flow_nominal",
-      "type": "Modelica.Units.SI.MassFlowRate",
-      "name": "Nominal mass flow rate of fully open valve",
-      "group": "Nominal condition",
-      "tab": "",
-      "visible": false,
-      "enable": {
-        "operator": "!=",
-        "operands": [
-          "typ",
-          "Buildings.Templates.Components.Types.Valve.None"
-        ]
-      },
-      "modifiers": {
-        "Buildings.Templates.Components.Data.Valve.m_flow_nominal.min": {
-          "expression": {
-            "operator": "none",
-            "operands": [
-              0
-            ]
-          },
-          "final": true
-        },
-        "Buildings.Templates.Components.Data.Valve.m_flow_nominal.start": {
-          "expression": {
-            "operator": "none",
-            "operands": [
-              1
-            ]
-          },
-          "final": false
-        }
-      },
-      "replaceable": false,
-      "options": [],
-      "definition": false,
-      "shortExclType": false
-    },
-    {
-      "modelicaPath": "Buildings.Templates.Components.Data.Valve.dpValve_nominal",
-      "type": "Modelica.Units.SI.PressureDifference",
-      "name": "Nominal pressure drop of fully open valve",
-      "group": "Nominal condition",
-      "tab": "",
-      "visible": false,
-      "enable": {
-        "operator": "!=",
-        "operands": [
-          "typ",
-          "Buildings.Templates.Components.Types.Valve.None"
-        ]
-      },
-      "modifiers": {
-        "Buildings.Templates.Components.Data.Valve.dpValve_nominal.min": {
-          "expression": {
-            "operator": "none",
-            "operands": [
-              0
-            ]
-          },
-          "final": true
-        },
-        "Buildings.Templates.Components.Data.Valve.dpValve_nominal.displayUnit": {
-          "expression": {
-            "operator": "none",
-            "operands": [
-              "Pa"
-            ]
-          },
-          "final": false
-        },
-        "Buildings.Templates.Components.Data.Valve.dpValve_nominal.start": {
-          "expression": {
-            "operator": "none",
-            "operands": [
-              0
-            ]
-          },
-          "final": false
-        }
-      },
-      "replaceable": false,
-      "options": [],
-      "definition": false,
-      "shortExclType": false
-    },
-    {
-      "modelicaPath": "Buildings.Templates.Components.Data.Valve.dpFixed_nominal",
-      "type": "Modelica.Units.SI.PressureDifference",
-      "value": {
-        "operator": "none",
-        "operands": [
-          0
-        ]
-      },
-      "name": "Nominal pressure drop of pipes and other equipment in flow leg",
-      "group": "Nominal condition",
-      "tab": "",
-      "visible": false,
-      "enable": {
-        "operator": "!=",
-        "operands": [
-          "typ",
-          "Buildings.Templates.Components.Types.Valve.None"
-        ]
-      },
-      "modifiers": {},
-      "replaceable": false,
-      "options": [],
-      "definition": false,
-      "shortExclType": false
-    },
-    {
-      "modelicaPath": "Buildings.Templates.Components.Data.Valve.dpFixedByp_nominal",
-      "type": "Modelica.Units.SI.PressureDifference",
-      "value": {
-        "operator": "none",
-        "operands": [
-          "dpFixed_nominal"
-        ]
-      },
-      "name": "Nominal pressure drop in the bypass line",
-      "group": "Nominal condition",
-      "tab": "",
-      "visible": false,
-      "enable": {
-        "operator": "||",
-        "operands": [
-          {
-            "operator": "==",
-            "operands": [
-              "typ",
-              "Buildings.Templates.Components.Types.Valve.ThreeWayTwoPosition"
-            ]
-          },
-          {
-            "operator": "==",
-            "operands": [
-              "typ",
-              "Buildings.Templates.Components.Types.Valve.ThreeWayModulating"
-            ]
-          }
-        ]
-      },
-      "modifiers": {},
-      "replaceable": false,
-      "options": [],
-      "definition": false,
-      "shortExclType": false
-    },
-    {
-      "modelicaPath": "Buildings.Templates.Components.Data.Valve",
-      "type": "Buildings.Templates.Components.Data.Valve",
-      "name": "Record for valve model",
-      "visible": false,
-      "modifiers": {},
-      "replaceable": false,
-      "options": [
-        "Buildings.Templates.Components.Data.Valve.typ",
-        "Buildings.Templates.Components.Data.Valve.m_flow_nominal",
-        "Buildings.Templates.Components.Data.Valve.dpValve_nominal",
-        "Buildings.Templates.Components.Data.Valve.dpFixed_nominal",
-        "Buildings.Templates.Components.Data.Valve.dpFixedByp_nominal"
-      ],
-      "definition": true,
-      "shortExclType": false,
-      "treeList": [
-        "Buildings.Templates.Components.Data.Valve"
-      ]
     },
     {
       "modelicaPath": "Buildings.Templates.Components.Actuators.Valve.dpValve_nominal",
@@ -28224,7 +28311,8 @@
         "Buildings.Templates.Components.Interfaces.PartialCoil.port_aSou",
         "Buildings.Templates.Components.Interfaces.PartialCoil.port_bSou",
         "Buildings.Templates.Components.Interfaces.PartialCoil.busWea",
-        "Buildings.Templates.Components.Interfaces.PartialCoil.bus"
+        "Buildings.Templates.Components.Interfaces.PartialCoil.bus",
+        "Buildings.Templates.Components.Interfaces.PartialCoil.datVal"
       ],
       "definition": true,
       "shortExclType": false,
@@ -29053,7 +29141,8 @@
         "Buildings.Templates.Components.Interfaces.PartialCoil.port_aSou",
         "Buildings.Templates.Components.Interfaces.PartialCoil.port_bSou",
         "Buildings.Templates.Components.Interfaces.PartialCoil.busWea",
-        "Buildings.Templates.Components.Interfaces.PartialCoil.bus"
+        "Buildings.Templates.Components.Interfaces.PartialCoil.bus",
+        "Buildings.Templates.Components.Interfaces.PartialCoil.datVal"
       ],
       "definition": true,
       "shortExclType": false,
@@ -30278,7 +30367,8 @@
         "Buildings.Templates.Components.Interfaces.PartialCoil.port_aSou",
         "Buildings.Templates.Components.Interfaces.PartialCoil.port_bSou",
         "Buildings.Templates.Components.Interfaces.PartialCoil.busWea",
-        "Buildings.Templates.Components.Interfaces.PartialCoil.bus"
+        "Buildings.Templates.Components.Interfaces.PartialCoil.bus",
+        "Buildings.Templates.Components.Interfaces.PartialCoil.datVal"
       ],
       "definition": true,
       "shortExclType": false,
@@ -67794,6 +67884,247 @@
       "shortExclType": false
     },
     {
+      "modelicaPath": "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.datDamVAV",
+      "type": "Buildings.Templates.Components.Data.Damper",
+      "name": "Local record for VAV damper with lumped flow resistance",
+      "group": "",
+      "tab": "",
+      "visible": false,
+      "enable": true,
+      "modifiers": {
+        "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.datDamVAV.typ": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "damVAV.typ"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.datDamVAV.m_flow_nominal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dat.damVAV.m_flow_nominal"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.datDamVAV.dp_nominal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dat.damVAV.dp_nominal"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.datDamVAV.dpFixed_nominal": {
+          "expression": {
+            "operator": "if_elseif",
+            "operands": [
+              {
+                "operator": "if",
+                "operands": [
+                  {
+                    "operator": "==",
+                    "operands": [
+                      "damVAV.typ",
+                      "Buildings.Templates.Components.Types.Damper.None"
+                    ]
+                  },
+                  {
+                    "operator": "none",
+                    "operands": [
+                      0
+                    ]
+                  }
+                ]
+              },
+              {
+                "operator": "else",
+                "operands": [
+                  {
+                    "operator": "none",
+                    "operands": [
+                      "dat.coiHea.dpAir_nominal"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "final": true
+        }
+      },
+      "replaceable": false,
+      "options": [
+        "Buildings.Templates.Components.Data.Damper.typ",
+        "Buildings.Templates.Components.Data.Damper.m_flow_nominal",
+        "Buildings.Templates.Components.Data.Damper.dp_nominal",
+        "Buildings.Templates.Components.Data.Damper.dpFixed_nominal"
+      ],
+      "definition": false,
+      "shortExclType": false
+    },
+    {
+      "modelicaPath": "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.datCoiHea",
+      "type": "Buildings.Templates.Components.Data.Coil",
+      "name": "Local record for coil with lumped flow resistance",
+      "group": "",
+      "tab": "",
+      "visible": false,
+      "enable": true,
+      "modifiers": {
+        "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.datCoiHea.typ": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "coiHea.typ"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.datCoiHea.typVal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "coiHea.typVal"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.datCoiHea.have_sou": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "coiHea.have_sou"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.datCoiHea.mAir_flow_nominal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dat.coiHea.mAir_flow_nominal"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.datCoiHea.mWat_flow_nominal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dat.coiHea.mWat_flow_nominal"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.datCoiHea.dpWat_nominal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dat.coiHea.dpWat_nominal"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.datCoiHea.dpValve_nominal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dat.coiHea.dpValve_nominal"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.datCoiHea.cap_nominal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dat.coiHea.cap_nominal"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.datCoiHea.TWatEnt_nominal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dat.coiHea.TWatEnt_nominal"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.datCoiHea.TAirEnt_nominal": {
+          "expression": {
+            "operator": "none",
+            "operands": [
+              "dat.coiHea.TAirEnt_nominal"
+            ]
+          },
+          "final": true
+        },
+        "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.datCoiHea.dpAir_nominal": {
+          "expression": {
+            "operator": "if_elseif",
+            "operands": [
+              {
+                "operator": "if",
+                "operands": [
+                  {
+                    "operator": "==",
+                    "operands": [
+                      "damVAV.typ",
+                      "Buildings.Templates.Components.Types.Damper.None"
+                    ]
+                  },
+                  {
+                    "operator": "none",
+                    "operands": [
+                      "dat.coiHea.dpAir_nominal"
+                    ]
+                  }
+                ]
+              },
+              {
+                "operator": "else",
+                "operands": [
+                  {
+                    "operator": "none",
+                    "operands": [
+                      0
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "final": true
+        }
+      },
+      "replaceable": false,
+      "options": [
+        "Buildings.Templates.Components.Data.Coil.typ",
+        "Buildings.Templates.Components.Data.Coil.typVal",
+        "Buildings.Templates.Components.Data.Coil.have_sou",
+        "Buildings.Templates.Components.Data.Coil.mAir_flow_nominal",
+        "Buildings.Templates.Components.Data.Coil.dpAir_nominal",
+        "Buildings.Templates.Components.Data.Coil.mWat_flow_nominal",
+        "Buildings.Templates.Components.Data.Coil.dpWat_nominal",
+        "Buildings.Templates.Components.Data.Coil.dpValve_nominal",
+        "Buildings.Templates.Components.Data.Coil.cap_nominal",
+        "Buildings.Templates.Components.Data.Coil.Q_flow_nominal",
+        "Buildings.Templates.Components.Data.Coil.TWatEnt_nominal",
+        "Buildings.Templates.Components.Data.Coil.TAirEnt_nominal",
+        "Buildings.Templates.Components.Data.Coil.wAirEnt_nominal",
+        "Buildings.Templates.Components.Data.Coil.datCoi"
+      ],
+      "definition": false,
+      "shortExclType": false
+    },
+    {
       "modelicaPath": "Buildings.Templates.ZoneEquipment.Interfaces.PartialAirTerminal.typ",
       "type": "Buildings.Templates.ZoneEquipment.Types.Configuration",
       "name": "Type of system",
@@ -69188,6 +69519,8 @@
         "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.ctl",
         "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.TAirDis",
         "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.VAirDis_flow",
+        "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.datDamVAV",
+        "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.datCoiHea",
         "Buildings.Templates.ZoneEquipment.Interfaces.PartialAirTerminal.typ",
         "Buildings.Templates.ZoneEquipment.Interfaces.PartialAirTerminal.id",
         "Buildings.Templates.ZoneEquipment.Interfaces.PartialAirTerminal.have_souChiWat",
@@ -69246,6 +69579,8 @@
         "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.ctl",
         "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.TAirDis",
         "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.VAirDis_flow",
+        "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.datDamVAV",
+        "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.datCoiHea",
         "Buildings.Templates.ZoneEquipment.Interfaces.PartialAirTerminal.typ",
         "Buildings.Templates.ZoneEquipment.Interfaces.PartialAirTerminal.id",
         "Buildings.Templates.ZoneEquipment.Interfaces.PartialAirTerminal.have_souChiWat",
@@ -82445,6 +82780,8 @@
         "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.ctl",
         "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.TAirDis",
         "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.VAirDis_flow",
+        "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.datDamVAV",
+        "Buildings.Templates.ZoneEquipment.Interfaces.VAVBox.datCoiHea",
         "Buildings.Templates.ZoneEquipment.Interfaces.PartialAirTerminal.typ",
         "Buildings.Templates.ZoneEquipment.Interfaces.PartialAirTerminal.id",
         "Buildings.Templates.ZoneEquipment.Interfaces.PartialAirTerminal.have_souChiWat",

--- a/server/src/parser/loader.ts
+++ b/server/src/parser/loader.ts
@@ -129,7 +129,7 @@ export function findPackageEntryPoints(
 
       for (let templateJson of [...templateNodes.map(({ json }) => json)]) {
         let packageName = (templateJson as any).within;
-        while (packageName && packageName !== rootPackageName) {
+        while (packageName) {
           const packagePath = getPathFromClassName(packageName, dir);
           if (!packagePath) {
             break;
@@ -150,15 +150,21 @@ export function findPackageEntryPoints(
           PACKAGE_LIST.push(packageNode.className);
           templateNodes.push(packageNode);
 
+          if (packageName === rootPackageName) {
+            break;
+          }
           packageName = (packageJson as any).within;
         }
       }
     }
   });
-
-  return templateNodes.map(({ className, json }) => {
-    return { className, json };
-  });
+  PACKAGE_LIST.sort();
+  TEMPLATE_LIST.sort();
+  templateNodes.sort();
+  return templateNodes
+    .map(({ className, json }) => {
+      return { className, json };
+    });
 }
 
 /**

--- a/server/src/parser/parser.ts
+++ b/server/src/parser/parser.ts
@@ -442,6 +442,7 @@ export abstract class Element {
   final = false;
   inner: boolean | null = null;
   outer: boolean | null = null;
+  isProtected?: true;
   tab = "";
   group = "";
 
@@ -610,6 +611,33 @@ export class LongClass extends Element {
         ?.filter((e: Element | undefined) => e !== undefined)
         ?.filter((e: Element) => e.elementType !== "extends_clause") || [];
 
+    const processSection = (list: any[], isProtected: boolean): Element[] =>
+      (list ?? [])
+        .map((e: any) => {
+          const element = _constructElement(e, this.modelicaPath);
+          if (element?.elementType === "extends_clause") {
+            const extendParam = element as Extend;
+            this.mods = extendParam.mods;
+            this.extendElement = typeStore.get(extendParam.type) as LongClass;
+            this.extendElementDeadEnd = extendParam.deadEnd;
+          }
+          if (element && isProtected) {
+            element.isProtected = true;
+          }
+          return element;
+        })
+        .filter((e): e is Element => e !== undefined)
+        .filter((e) => e.elementType !== "extends_clause");
+
+    const sectionElements = (
+      specifier.composition?.element_sections ?? []
+    ).flatMap((section: any) => [
+      ...processSection(section.public_element_list, false),
+      ...processSection(section.protected_element_list, true),
+    ]);
+
+    this.elementList = [...(this.elementList ?? []), ...sectionElements];
+
     this.annotation = specifier.composition?.annotation?.map(
       (m: mj.Mod | mj.WrappedMod) => createModification({ definition: m }),
     );
@@ -748,6 +776,7 @@ function setInputVisible(
   let isVisible = !(
     instance.outer ||
     instance.final ||
+    instance.isProtected ||
     connectorSizing === true
   );
 

--- a/server/src/parser/parser.ts
+++ b/server/src/parser/parser.ts
@@ -592,9 +592,9 @@ export class LongClass extends Element {
 
     this.description = specifier.description_string;
 
-    this.elementList =
-      specifier.composition?.element_list
-        ?.map((e: any) => {
+    const processSection = (list: any[], isProtected: boolean): Element[] =>
+      (list ?? [])
+        .map((e: any) => {
           const element = _constructElement(e, this.modelicaPath);
           if (element?.elementType === "extends_clause") {
             const extendParam = element as Extend;
@@ -606,21 +606,6 @@ export class LongClass extends Element {
             // change
             this.extendElementDeadEnd = extendParam.deadEnd;
           }
-          return element;
-        })
-        ?.filter((e: Element | undefined) => e !== undefined)
-        ?.filter((e: Element) => e.elementType !== "extends_clause") || [];
-
-    const processSection = (list: any[], isProtected: boolean): Element[] =>
-      (list ?? [])
-        .map((e: any) => {
-          const element = _constructElement(e, this.modelicaPath);
-          if (element?.elementType === "extends_clause") {
-            const extendParam = element as Extend;
-            this.mods = extendParam.mods;
-            this.extendElement = typeStore.get(extendParam.type) as LongClass;
-            this.extendElementDeadEnd = extendParam.deadEnd;
-          }
           if (element && isProtected) {
             element.isProtected = true;
           }
@@ -629,14 +614,19 @@ export class LongClass extends Element {
         .filter((e): e is Element => e !== undefined)
         .filter((e) => e.elementType !== "extends_clause");
 
-    const sectionElements = (
-      specifier.composition?.element_sections ?? []
-    ).flatMap((section: any) => [
+    const rootPackage = PACKAGE_LIST[0];
+    this.elementList = [
+      // Treat `element_list` as a synthetic public section
+      { public_element_list: specifier.composition?.element_list ?? [], protected_element_list: [] },
+      ...(specifier.composition?.element_sections ?? []),
+    ].flatMap((section: any) => [
       ...processSection(section.public_element_list, false),
-      ...processSection(section.protected_element_list, true),
+      // Only parse protected sections within the project root package — too costly to do across all classes.
+      // (The case with !rootPackage is for testing.)
+      ...(!rootPackage || this.modelicaPath.startsWith(rootPackage)
+        ? processSection(section.protected_element_list, true)
+        : []),
     ]);
-
-    this.elementList = [...(this.elementList ?? []), ...sectionElements];
 
     this.annotation = specifier.composition?.annotation?.map(
       (m: mj.Mod | mj.WrappedMod) => createModification({ definition: m }),

--- a/server/tests/integration/parser/loader.test.ts
+++ b/server/tests/integration/parser/loader.test.ts
@@ -27,6 +27,7 @@ describe("Parser file loading", () => {
       .map(({className}) => className)
       .sort();
     expect(entryPointNames).toEqual([
+      'TestPackage',
       'TestPackage.NestedTemplate',
       'TestPackage.NestedTemplate.Subcategory',
       'TestPackage.NestedTemplate.Subcategory.SecondTemplate',

--- a/server/tests/integration/parser/parsed-elements.test.ts
+++ b/server/tests/integration/parser/parsed-elements.test.ts
@@ -260,3 +260,47 @@ describe("Expected elements are extracted", () => {
     expect(forcedFalse.enable).toBeFalsy();
   });
 });
+
+describe("Element sections public and protected", () => {
+  beforeAll(() => {
+    initializeTestModelicaJson();
+  });
+
+  it("includes elements from all element_sections in elementList", () => {
+    const file = parser.getFile("TestPackage.MultipleSections") as parser.File;
+    const cls = file.elementList[0] as parser.LongClass;
+    const names = cls.elementList?.map((e) => e.name) ?? [];
+    expect(names).toContain("p");
+    expect(names).toContain("q");
+    expect(names).toContain("r");
+    expect(names).toContain("s");
+    expect(names).toContain("t");
+    expect(cls.elementList?.length).toBe(5);
+  });
+
+  it("marks elements from protected_element_list with isProtected", () => {
+    const file = parser.getFile("TestPackage.MultipleSections") as parser.File;
+    const cls = file.elementList[0] as parser.LongClass;
+    const byName = Object.fromEntries(
+      (cls.elementList ?? []).map((e) => [e.name, e]),
+    );
+    expect(byName["q"].isProtected).toBe(true);
+    expect(byName["s"].isProtected).toBe(true);
+    expect(byName["p"].isProtected).toBeUndefined();
+    expect(byName["r"].isProtected).toBeUndefined();
+    expect(byName["t"].isProtected).toBeUndefined();
+  });
+
+  it("sets visible=false for protected elements, visible=true for public elements", () => {
+    const file = parser.getFile("TestPackage.MultipleSections") as parser.File;
+    const cls = file.elementList[0] as parser.LongClass;
+    const inputs = cls.getInputs();
+    expect(inputs["TestPackage.MultipleSections.q"]).toBeDefined();
+    expect(inputs["TestPackage.MultipleSections.q"].visible).toBe(false);
+    expect(inputs["TestPackage.MultipleSections.s"]).toBeDefined();
+    expect(inputs["TestPackage.MultipleSections.s"].visible).toBe(false);
+    expect(inputs["TestPackage.MultipleSections.p"].visible).toBe(true);
+    expect(inputs["TestPackage.MultipleSections.r"].visible).toBe(true);
+    expect(inputs["TestPackage.MultipleSections.t"].visible).toBe(true);
+  });
+});

--- a/server/tests/static-data/TestPackage/MultipleSections.mo
+++ b/server/tests/static-data/TestPackage/MultipleSections.mo
@@ -1,0 +1,12 @@
+within TestPackage;
+model MultipleSections "Multiple element sections"
+  parameter Real p;
+protected
+  parameter Real q;
+public
+  parameter Real r;
+protected
+  parameter Real s;
+public
+  parameter Real t;
+end MultipleSections;


### PR DESCRIPTION
### Description

See #494 

### Testing

Unit tests have been included: `npx jest -t "Element sections public and protected"`

End-to-end tests have also been performed by creating the SOO document with the following system options.

AHU

- Separate dampers w/ dp
- Modulating relief w/o fan
- No heating coil
- Freeze stat hardwired to both

Cooling-only box

- 3 sensors = true

✅ The parameter dialogs are identical to the ones on main: no additional protected parameters displayed.
✅ The feature branch produces the same document as the main branch.
